### PR TITLE
Feat/user profile: 유저 프로필 관련 기능, S3 이미지, 초대 코드 및 커플 연결/해제 기능 구현

### DIFF
--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -34,9 +34,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Retry & AOP
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // Database (JPA + PostgreSQL)
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly    'org.postgresql:postgresql:42.2.5'
+
+    // Key-Value Store (Redis)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -48,6 +48,9 @@ dependencies {
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // String utilities
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+
     // AWS SDK for S3
     implementation 'software.amazon.awssdk:s3:2.20.124'
 

--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // AWS SDK for S3
+    implementation 'software.amazon.awssdk:s3:2.20.124'
+
     // Service Discovery (Eureka Client)
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     // 2xxx: 인프라(시스템) 오류
     DB_SAVE_FAILURE(2101, "System error occurred while saving data to the database"),
     DB_DELETE_FAILURE(2102, "System error occurred while deleting data from the database"),
-    DB_RETRIEVE_FAILURE(2103, "System error occurred while retrieving data from the database");
+    DB_RETRIEVE_FAILURE(2103, "System error occurred while retrieving data from the database"),
+    S3_UPLOAD_FAILURE(2104, "System error occurred while uploading image to S3");
 
     private final int code;
     private final String message;

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -12,7 +12,11 @@ public enum ErrorCode {
     DB_SAVE_FAILURE(2101, "System error occurred while saving data to the database"),
     DB_DELETE_FAILURE(2102, "System error occurred while deleting data from the database"),
     DB_RETRIEVE_FAILURE(2103, "System error occurred while retrieving data from the database"),
-    S3_UPLOAD_FAILURE(2104, "System error occurred while uploading image to S3");
+    S3_UPLOAD_FAILURE(2104, "System error occurred while uploading image to S3"),
+    INVITE_CODE_SAVE_FAILURE(2105, "System error occurred while saving invite code to redis"),
+    INVITE_CODE_DELETE_FAILURE(2106, "System error occurred while deleting invite code from redis"),
+    INVITE_CODE_RETRIEVE_FAILURE(2107, "System error occurred while retrieving invite code from redis"),
+    INVITE_CODE_GENERATION_FAILURE(2108, "System error occurred while generating unique invite code after multiple attempts");
 
     private final int code;
     private final String message;

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     CANNOT_CONNECT_TO_SELF(1102, "Cannot connect couple to self"),
     ALREADY_CONNECTED_SELF(1103, "Current user is already connected"),
     ALREADY_CONNECTED_PARTNER(1104, "Target user is already connected"),
+    ALREADY_RELEASED(1105, "Couple already released or not connected"),
 
     // 2xxx: 인프라(시스템) 오류
     DB_SAVE_FAILURE(2101, "System error occurred while saving data to the database"),

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -7,6 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
     // 1xxx: 비즈니스 오류
+    INVALID_INVITE_CODE(1101, "Invite code does not exist or has expired"),
+    CANNOT_CONNECT_TO_SELF(1102, "Cannot connect couple to self"),
+    ALREADY_CONNECTED_SELF(1103, "Current user is already connected"),
+    ALREADY_CONNECTED_PARTNER(1104, "Target user is already connected"),
 
     // 2xxx: 인프라(시스템) 오류
     DB_SAVE_FAILURE(2101, "System error occurred while saving data to the database"),

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/GlobalExceptionHandler.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/GlobalExceptionHandler.java
@@ -14,7 +14,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import ready_to_marry.userservice.common.dto.response.ApiResponse;
 import ready_to_marry.userservice.common.dto.response.ErrorDetail;
 
-import java.nio.file.AccessDeniedException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -98,20 +97,6 @@ public class GlobalExceptionHandler {
                 .errors(errors)
                 .build();
         return ResponseEntity.badRequest().body(body);
-    }
-
-    /**
-     * 인가 오류 예외 처리
-     * HTTP 403 + code=403
-     */
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(AccessDeniedException ex) {
-        ApiResponse<Void> body = ApiResponse.<Void>builder()
-                .code(403)
-                .message("Forbidden")
-                .data(null)
-                .build();
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
     }
 
     /**

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/GlobalExceptionHandler.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/GlobalExceptionHandler.java
@@ -48,7 +48,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             MethodArgumentNotValidException.class,
             ConstraintViolationException.class,
-            MethodArgumentTypeMismatchException.class
+            MethodArgumentTypeMismatchException.class,
+            ValidationException.class
     })
     public ResponseEntity<ApiResponse<Void>> handleValidation(Exception ex) {
         List<ErrorDetail> errors = new ArrayList<>();
@@ -80,6 +81,13 @@ public class GlobalExceptionHandler {
             errors.add(ErrorDetail.builder()
                     .field(field)
                     .reason(msg)
+                    .build());
+        }
+        else if (ex instanceof ValidationException ve) {
+            // 단일 필드 검증 실패
+            errors.add(ErrorDetail.builder()
+                    .field(ve.getField())
+                    .reason(ve.getReason())
                     .build());
         }
 

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ValidationException.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ValidationException.java
@@ -1,0 +1,22 @@
+package ready_to_marry.userservice.common.exception;
+
+import lombok.Getter;
+
+/**
+ * 서비스 로직 내부에서 발생하는 단일 필드 검증 오류를 나타내는 런타임 예외
+ */
+@Getter
+public class ValidationException extends RuntimeException {
+    private final String field;
+    private final String reason;
+
+    /**
+     * @param field 검증에 실패한 필드 이름
+     * @param reason 해당 필드의 검증 실패 사유
+     */
+    public ValidationException(String field, String reason) {
+        super(String.format("Validation failed: %s - %s", field, reason));
+        this.field = field;
+        this.reason = reason;
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
@@ -76,4 +76,32 @@ public final class MaskingUtils {
         // 뒤 2자리만 남기고 마스킹
         return "*".repeat(len - 2) + str.substring(len - 2);
     }
+
+    /**
+     * 커플 초대 코드 부분 마스킹
+     * 길이 2 이하: 전체 마스킹
+     * 길이 3~4: 앞/뒤 한 글자만 남기고 마스킹 (A**Z)
+     * 길이 5 이상: 앞 2글자, 뒤 2글자 제외한 가운데 마스킹 (AB***YZ)
+     */
+    public static String maskInviteCode(String inviteCode) {
+        if (inviteCode == null || inviteCode.isBlank()) return "";
+
+        int len = inviteCode.length();
+
+        if (len <= 2) {
+            // 1~2자리면 전부 마스킹
+            return "*".repeat(len);
+        } else if (len <= 4) {
+            // 앞 1, 뒤 1 제외
+            return inviteCode.charAt(0)
+                    + "*".repeat(len - 2)
+                    + inviteCode.charAt(len - 1);
+        } else {
+            // 앞 2, 뒤 2 제외
+            String start = inviteCode.substring(0, 2);
+            String end = inviteCode.substring(len - 2);
+            String midMask = "*".repeat(len - 4);
+            return start + midMask + end;
+        }
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
@@ -57,4 +57,23 @@ public final class MaskingUtils {
             return prefix + start + mid + end;
         }
     }
+
+    /**
+     * 유저 도메인 ID 부분 마스킹 (예: 123456 → ****56)
+     * null 또는 음수일 경우 빈 문자열 반환
+     */
+    public static String maskUserId(Long userId) {
+        if (userId == null || userId < 0) return "";
+
+        String str = String.valueOf(userId);
+        int len = str.length();
+
+        // 1~2자리면 전부 마스킹
+        if (len <= 2) {
+            return "*".repeat(len);
+        }
+
+        // 뒤 2자리만 남기고 마스킹
+        return "*".repeat(len - 2) + str.substring(len - 2);
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
@@ -4,4 +4,57 @@ public final class MaskingUtils {
     private MaskingUtils() {
         // 유틸 클래스이므로 인스턴스 생성 방지
     }
+
+    /**
+     * 전화번호 부분 마스킹
+     * - 하이픈 포함: 010-1234-5678 → 010-****-5678
+     * - 하이픈 없음: 01012345678 → 010****5678
+     * - 짧은 번호도 일부 마스킹 적용 (예: 0101 → ***1)
+     * - 국가번호(+82 등) 포함도 지원
+     * - 형식이 이상하더라도 최대한 보호
+     */
+    public static String maskPhone(String phone) {
+        if (phone == null || phone.isBlank()) return "";
+
+        // 하이픈 포함 케이스
+        if (phone.contains("-")) {
+            String[] parts = phone.split("-");
+            StringBuilder masked = new StringBuilder();
+
+            for (int i = 0; i < parts.length; i++) {
+                if (i != 0) masked.append("-");
+
+                // 가운데 블록 마스킹 (마지막 블록 제외)
+                if (i == parts.length - 2) {
+                    masked.append("*".repeat(parts[i].length()));
+                } else {
+                    masked.append(parts[i]);
+                }
+            }
+
+            return masked.toString();
+        }
+
+        // 하이픈 없는 케이스
+        String raw = phone.startsWith("+") ? phone.substring(1) : phone;
+        String prefix = phone.startsWith("+") ? "+" : "";
+
+        int len = raw.length();
+
+        if (len <= 1) {
+            return phone;
+        } else if (len <= 4) {
+            return prefix + "*".repeat(len - 1) + raw.substring(len - 1);
+        } else if (len <= 7) {
+            String start = raw.substring(0, 2);
+            String end = raw.substring(len - 2);
+            String mid = "*".repeat(len - 4);
+            return prefix + start + mid + end;
+        } else {
+            String start = raw.substring(0, 3);
+            String mid = "*".repeat(len - 7);
+            String end = raw.substring(len - 4);
+            return prefix + start + mid + end;
+        }
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
@@ -1,5 +1,7 @@
 package ready_to_marry.userservice.common.util;
 
+import java.util.UUID;
+
 public final class MaskingUtils {
     private MaskingUtils() {
         // 유틸 클래스이므로 인스턴스 생성 방지
@@ -103,5 +105,23 @@ public final class MaskingUtils {
             String midMask = "*".repeat(len - 4);
             return start + midMask + end;
         }
+    }
+
+    /**
+     * 커플 ID 부분 마스킹
+     *
+     * 예: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d → 1a2b...5c6d
+     */
+    public static String maskCoupleId(UUID coupleId) {
+        if (coupleId == null) return "";
+
+        String id = coupleId.toString().replace("-", "");
+        int len = id.length();
+
+        if (len <= 8) {
+            return "*".repeat(len);
+        }
+
+        return id.substring(0, 4) + "..." + id.substring(id.length() - 4);
     }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/config/InviteCodeProperties.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/config/InviteCodeProperties.java
@@ -1,0 +1,20 @@
+package ready_to_marry.userservice.profile.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * application.properties의 초대 코드 관련 설정을 바인딩
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "invite-code")
+public class InviteCodeProperties {
+    // 초대 코드 TTL
+    private Duration ttl;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/config/S3Properties.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/config/S3Properties.java
@@ -1,0 +1,43 @@
+package ready_to_marry.userservice.profile.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * application.properties의 S3 설정을 바인딩
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "cloud.aws")
+public class S3Properties {
+    // S3 업로드에 사용할 버킷 이름 설정
+    private S3 s3;
+
+    // AWS 액세스 키 및 시크릿 키 설정
+    private Credentials credentials;
+
+    // S3가 위치한 AWS 리전(region) 설정
+    private Region region;
+
+    @Getter
+    @Setter
+    public static class S3 {
+        private String bucket;
+    }
+
+    @Getter
+    @Setter
+    public static class Credentials {
+        private String accessKey;
+        private String secretKey;
+    }
+
+    @Getter
+    @Setter
+    public static class Region {
+        private String staticRegion;
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/InternalUserProfileController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/InternalUserProfileController.java
@@ -1,0 +1,42 @@
+package ready_to_marry.userservice.profile.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateRequest;
+import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
+import ready_to_marry.userservice.profile.service.UserProfileService;
+
+/**
+ * INTERNAL API 컨트롤러 - 유저 프로필 등록용
+ */
+@RestController
+@RequestMapping("/internal/user-profiles")
+@RequiredArgsConstructor
+public class InternalUserProfileController {
+    private final UserProfileService userProfileService;
+
+    /**
+     * 최소 정보(name, phone)로 유저 프로필 등록
+     *
+     * @param request 유저 프로필 등록 요청 정보
+     * @return 성공 시 code=0, data=생성된 유저의 도메인 ID 정보
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<InternalProfileCreateResponse>> createProfile(@Valid @RequestBody InternalProfileCreateRequest request) {
+        InternalProfileCreateResponse result = userProfileService.createInternalProfile(request);
+
+        ApiResponse<InternalProfileCreateResponse> response = ApiResponse.<InternalProfileCreateResponse>builder()
+                .code(0)
+                .message("User profile created successfully")
+                .data(result)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserCoupleController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserCoupleController.java
@@ -56,4 +56,23 @@ public class UserCoupleController {
 
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 현재 로그인한 유저의 커플 연결을 해제
+     *
+     * @param userId   게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @return 성공 시 code=0, data=null
+     */
+    @PostMapping("/couple-connection/release")
+    public ResponseEntity<ApiResponse<Void>> releaseCouple(@RequestHeader("X-User-Id") Long userId) {
+        userProfileService.releaseCouple(userId);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("Couple released successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserCoupleController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserCoupleController.java
@@ -38,7 +38,7 @@ public class UserCoupleController {
     }
 
     /**
-     * 초대 코드 기반으로 커플 연결
+     * 초대 코드 기반으로 현재 로그인한 유저의 커플 연결을 수행
      *
      * @param userId   게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
      * @param request  초대 코드가 포함된 유저의 커플 연결 요청 정보

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserCoupleController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserCoupleController.java
@@ -1,22 +1,21 @@
 package ready_to_marry.userservice.profile.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.profile.dto.request.CoupleConnectRequest;
 import ready_to_marry.userservice.profile.dto.response.InviteCodeIssueResponse;
 import ready_to_marry.userservice.profile.service.UserProfileService;
 
 /**
- * 유저의 초대 코드 발급을 처리하는 컨트롤러
+ * 유저의 커플 관련 기능을 처리하는 컨트롤러
  */
 @RestController
-@RequestMapping("/users/me/invite-code")
+@RequestMapping("/users/me")
 @RequiredArgsConstructor
-public class UserInviteController {
+public class UserCoupleController {
     private final UserProfileService userProfileService;
 
     /**
@@ -25,7 +24,7 @@ public class UserInviteController {
      * @param userId 게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
      * @return 성공 시 code=0, data=유저의 발급된 초대코드 정보
      */
-    @PostMapping
+    @PostMapping("/invite-code")
     public ResponseEntity<ApiResponse<InviteCodeIssueResponse>> issueInviteCode(@RequestHeader("X-User-Id") Long userId) {
         InviteCodeIssueResponse inviteCodeResponse  = userProfileService.issueInviteCode(userId);
 
@@ -33,6 +32,26 @@ public class UserInviteController {
                 .code(0)
                 .message("Invite code issued successfully")
                 .data(inviteCodeResponse)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 초대 코드 기반으로 커플 연결
+     *
+     * @param userId   게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param request  초대 코드가 포함된 유저의 커플 연결 요청 정보
+     * @return 성공 시 code=0, data=null
+     */
+    @PostMapping("/couple-connection")
+    public ResponseEntity<ApiResponse<Void>> connectCouple(@RequestHeader("X-User-Id") Long userId, @RequestBody @Valid CoupleConnectRequest request) {
+        userProfileService.connectCouple(userId, request);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("Couple connected successfully")
+                .data(null)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserInviteController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserInviteController.java
@@ -1,0 +1,40 @@
+package ready_to_marry.userservice.profile.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.profile.dto.response.InviteCodeIssueResponse;
+import ready_to_marry.userservice.profile.service.UserProfileService;
+
+/**
+ * 유저의 초대 코드 발급을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/users/me/invite-code")
+@RequiredArgsConstructor
+public class UserInviteController {
+    private final UserProfileService userProfileService;
+
+    /**
+     * 현재 로그인한 유저의 초대 코드를 발급
+     *
+     * @param userId 게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @return 성공 시 code=0, data=유저의 발급된 초대코드 정보
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<InviteCodeIssueResponse>> issueInviteCode(@RequestHeader("X-User-Id") Long userId) {
+        InviteCodeIssueResponse inviteCodeResponse  = userProfileService.issueInviteCode(userId);
+
+        ApiResponse<InviteCodeIssueResponse> response = ApiResponse.<InviteCodeIssueResponse>builder()
+                .code(0)
+                .message("Invite code issued successfully")
+                .data(inviteCodeResponse)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserProfileController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserProfileController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ready_to_marry.userservice.common.dto.response.ApiResponse;
 import ready_to_marry.userservice.profile.dto.request.ProfileUpdateRequest;
+import ready_to_marry.userservice.profile.dto.response.UserProfileResponse;
 import ready_to_marry.userservice.profile.service.UserProfileService;
 
 /**
@@ -31,6 +32,25 @@ public class UserProfileController {
                 .code(0)
                 .message("User profile updated successfully")
                 .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 현재 로그인한 유저의 프로필을 조회
+     *
+     * @param userId 게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @return 성공 시 code=0, data=유저 프로필 정보
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getMyProfile(@RequestHeader("X-User-Id") Long userId) {
+        UserProfileResponse profile = userProfileService.getMyProfile(userId);
+
+        ApiResponse<UserProfileResponse> response = ApiResponse.<UserProfileResponse>builder()
+                .code(0)
+                .message("User profile retrieved successfully")
+                .data(profile)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserProfileController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserProfileController.java
@@ -1,0 +1,38 @@
+package ready_to_marry.userservice.profile.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.profile.dto.request.ProfileUpdateRequest;
+import ready_to_marry.userservice.profile.service.UserProfileService;
+
+/**
+ * 유저의 프로필 수정을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/users/me/profiles")
+@RequiredArgsConstructor
+public class UserProfileController {
+    private final UserProfileService userProfileService;
+
+    /**
+     * 현재 로그인한 유저의 프로필을 수정
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param request name, phone, profileImage 중 일부 또는 전체를 포함한 유저 프로필 수정 요청 정보
+     * @return 성공 시 code=0, data=null
+     */
+    @PatchMapping(consumes = "multipart/form-data")
+    public ResponseEntity<ApiResponse<Void>> updateMyProfile(@RequestHeader("X-User-Id") Long userId, @ModelAttribute ProfileUpdateRequest request) {
+        userProfileService.updateMyProfile(userId, request);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("User profile updated successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserProfileInternalController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/controller/UserProfileInternalController.java
@@ -18,7 +18,7 @@ import ready_to_marry.userservice.profile.service.UserProfileService;
 @RestController
 @RequestMapping("/internal/user-profiles")
 @RequiredArgsConstructor
-public class InternalUserProfileController {
+public class UserProfileInternalController {
     private final UserProfileService userProfileService;
 
     /**

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/request/CoupleConnectRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/request/CoupleConnectRequest.java
@@ -1,0 +1,18 @@
+package ready_to_marry.userservice.profile.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 유저의 커플 연결 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CoupleConnectRequest {
+    // 상대방이 발급한 초대 코드
+    @NotBlank
+    private String inviteCode;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/request/InternalProfileCreateRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/request/InternalProfileCreateRequest.java
@@ -1,0 +1,29 @@
+package ready_to_marry.userservice.profile.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+/**
+ * Internal API를 통해 전달되는 유저 프로필 등록 요청 DTO
+ *
+ * Auth Service가 소셜 로그인 후 User Service에 프로필 생성 요청을
+ * 보낼 때 사용하는 내부용 데이터 모델
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InternalProfileCreateRequest {
+    // 유저 실명(또는 표시명)
+    @NotBlank
+    @Size(max = 50)
+    private String name;
+
+    // 유저 연락처: 맨 앞에 + 가 0~1회 올 수 있고 그 뒤에는 숫자나 하이픈만 조합
+    @NotBlank
+    @Pattern(regexp = "^\\+?[0-9\\-]{1,20}$")
+    private String phone;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/request/ProfileUpdateRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,27 @@
+package ready_to_marry.userservice.profile.dto.request;
+
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 유저의 프로필 수정 요청 DTO (multipart/form-data 전용)
+ *
+ * name, phone, profileImage 중 존재하는 필드만 수정
+ * 빈 값(null)인 경우 해당 필드는 수정하지 않음 (null 체크 기반 머지)
+ * 별도 검증 로직은 서비스 내부에서 처리 (전화번호 정규식, 파일 유효성 등)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileUpdateRequest {
+    // 유저 실명(또는 표시명) (선택 수정)
+    private String name;
+
+    // 유저 연락처 (선택 수정)
+    private String phone;
+
+    // 프로필 이미지 파일 (선택 수정, S3 업로드 대상)
+    private MultipartFile profileImage;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/InternalProfileCreateResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/InternalProfileCreateResponse.java
@@ -1,0 +1,19 @@
+package ready_to_marry.userservice.profile.dto.response;
+
+import lombok.*;
+
+/**
+ * Internal API 유저 프로필 등록 결과 응답 DTO
+ *
+ * Auth Service가 소셜 로그인 후 User Service에 프로필 생성 요청을 보낼 때,
+ * 성공적으로 생성된 유저의 도메인 ID를 담아 반환하는 내부용 데이터 모델
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InternalProfileCreateResponse {
+    // 유저 도메인 ID
+    private Long userId;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/InviteCodeIssueResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/InviteCodeIssueResponse.java
@@ -1,0 +1,16 @@
+package ready_to_marry.userservice.profile.dto.response;
+
+import lombok.*;
+
+/**
+ * 초대 코드 발급 결과 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InviteCodeIssueResponse {
+    // 발급된 초대 코드
+    private String inviteCode;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/UserProfileResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/UserProfileResponse.java
@@ -1,0 +1,25 @@
+package ready_to_marry.userservice.profile.dto.response;
+
+import lombok.*;
+
+/**
+ * 로그인한 유저의 프로필 조회 결과 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileResponse {
+    // 유저 실명(또는 표시명)
+    private String name;
+
+    // 유저 연락처
+    private String phone;
+
+    // 프로필 사진 저장 주소
+    private String profileImgUrl;
+
+    // 커플 연결 여부
+    private boolean connectedCouple;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/entity/UserProfile.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/entity/UserProfile.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 /**
  * user_db.user_profile 테이블 매핑 엔티티
@@ -25,7 +26,7 @@ public class UserProfile {
 
     // 커플 ID
     @Column(name = "couple_id")
-    private Long coupleId;
+    private UUID coupleId;
 
     // 유저 실명(또는 표시명)
     @Column(name = "name", length = 50, nullable = false)

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/entity/UserProfile.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/entity/UserProfile.java
@@ -1,0 +1,46 @@
+package ready_to_marry.userservice.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.OffsetDateTime;
+
+/**
+ * user_db.user_profile 테이블 매핑 엔티티
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "user_profile")
+public class UserProfile {
+    // PK 유저 도메인 ID
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", updatable = false, nullable = false)
+    private Long userId;
+
+    // 커플 ID
+    @Column(name = "couple_id")
+    private Long coupleId;
+
+    // 유저 실명(또는 표시명)
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    // 유저 연락처
+    @Column(name = "phone", length = 20, nullable = false)
+    private String phone;
+
+    // 프로필 사진 저장 주소
+    @Column(name = "profile_img_url", length = 2048)
+    private String profileImgUrl;
+
+    // 유저 프로필 생성 시각
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private OffsetDateTime createdAt;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/redis/InviteCodeRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/redis/InviteCodeRepository.java
@@ -20,7 +20,7 @@ public interface InviteCodeRepository {
      * 초대 코드로 발급자(userId) 조회
      *
      * @param code      초대 코드
-     * @return          유저 도메인 ID (없으면 Optional.empty())
+     * @return 유저 도메인 ID (없으면 Optional.empty())
      */
     Optional<Long> findUserIdByCode(String code);
 

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/redis/InviteCodeRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/redis/InviteCodeRepository.java
@@ -1,0 +1,33 @@
+package ready_to_marry.userservice.profile.redis;
+
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * 초대코드 저장소 추상화 인터페이스
+ */
+public interface InviteCodeRepository {
+    /**
+     * 초대코드를 Redis에 저장
+     *
+     * @param code      초대 코드
+     * @param userId    발급한 유저의 도메인 ID
+     * @param ttl       초대 코드 유효 기간(Duration)
+     */
+    void save(String code, Long userId, Duration ttl);
+
+    /**
+     * 초대 코드로 발급자(userId) 조회
+     *
+     * @param code      초대 코드
+     * @return          유저 도메인 ID (없으면 Optional.empty())
+     */
+    Optional<Long> findUserIdByCode(String code);
+
+    /**
+     * 초대 코드 삭제
+     *
+     * @param code      삭제할 초대 코드
+     */
+    void delete(String code);
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/redis/RedisInviteCodeRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/redis/RedisInviteCodeRepository.java
@@ -1,0 +1,39 @@
+package ready_to_marry.userservice.profile.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisInviteCodeRepository implements InviteCodeRepository {
+    private static final String KEY_PREFIX = "invite:code:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void save(String code, Long userId, Duration ttl) {
+        String key = generateKey(code);
+        redisTemplate.opsForValue().set(key, String.valueOf(userId), ttl);
+    }
+
+    @Override
+    public Optional<Long> findUserIdByCode(String code) {
+        String key = generateKey(code);
+        String value = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(value).map(Long::valueOf);
+    }
+
+    @Override
+    public void delete(String code) {
+        String key = generateKey(code);
+        redisTemplate.delete(key);
+    }
+
+    private String generateKey(String code) {
+        return KEY_PREFIX + code;
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/repository/UserProfileRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/repository/UserProfileRepository.java
@@ -1,0 +1,12 @@
+package ready_to_marry.userservice.profile.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ready_to_marry.userservice.profile.entity.UserProfile;
+
+/**
+ * UserProfile CRUD 및 조회용 레포지토리
+ */
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/repository/UserProfileRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/repository/UserProfileRepository.java
@@ -4,9 +4,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ready_to_marry.userservice.profile.entity.UserProfile;
 
+import java.util.List;
+import java.util.UUID;
+
 /**
  * UserProfile CRUD 및 조회용 레포지토리
  */
 @Repository
 public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+    /**
+     * 커플 ID로 유저 프로필 리스트 조회
+     *
+     * @param coupleId 유저의 커플 ID
+     * @return Optional.empty()이면 미존재
+     */
+    List<UserProfile> findByCoupleId(UUID coupleId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/InviteCodeService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/InviteCodeService.java
@@ -1,0 +1,31 @@
+package ready_to_marry.userservice.profile.service;
+
+import java.util.Optional;
+
+/**
+ * 초대 코드 저장·조회·삭제 기능 제공
+ */
+public interface InviteCodeService {
+    /**
+     * 초대 코드를 Redis에 저장
+     *
+     * @param code      생성된 초대 코드
+     * @param userId    초대 코드 발급자(user)의 도메인 ID
+     */
+    void save(String code, Long userId);
+
+    /**
+     * 초대 코드로 발급자(userId) 조회
+     *
+     * @param code      초대 코드
+     * @return 발급자 도메인 ID (없으면 Optional.empty())
+     */
+    Optional<Long> getUserIdByInviteCode(String code);
+
+    /**
+     * 초대 코드 삭제
+     *
+     * @param code      삭제할 초대 코드
+     */
+    void delete(String code);
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/InviteCodeServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/InviteCodeServiceImpl.java
@@ -1,0 +1,48 @@
+package ready_to_marry.userservice.profile.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import ready_to_marry.userservice.profile.config.InviteCodeProperties;
+import ready_to_marry.userservice.profile.redis.InviteCodeRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class InviteCodeServiceImpl implements InviteCodeService {
+    private final InviteCodeRepository inviteCodeRepository;
+    private final InviteCodeProperties inviteCodeProperties;
+
+    @Override
+    @Retryable(
+            include = DataAccessException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public void save(String code, Long userId) {
+        inviteCodeRepository.save(code, userId, inviteCodeProperties.getTtl());
+    }
+
+    @Override
+    @Retryable(
+            include = DataAccessException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public Optional<Long> getUserIdByInviteCode(String code) {
+        return inviteCodeRepository.findUserIdByCode(code);
+    }
+
+    @Override
+    @Retryable(
+            include = DataAccessException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public void delete(String code) {
+        inviteCodeRepository.delete(code);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -1,0 +1,22 @@
+package ready_to_marry.userservice.profile.service;
+
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateRequest;
+import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
+
+/**
+ * 유저 프로필 도메인의 비즈니스 로직을 제공하는 서비스 인터페이스
+ */
+public interface UserProfileService {
+    /**
+     * Internal API로 전달받은 최소 프로필 정보(name, phone)를 저장
+     * 1) 전달받은 name, phone 값으로 UserProfile 엔티티 생성
+     * 2) user_profile 테이블에 저장
+     * 3) 생성된 userId를 포함한 응답 DTO 반환
+     *
+     * @param request name, phone 포함 요청 DTO
+     * @return InternalProfileCreateResponse 생성된 userId 포함 응답 DTO
+     * @throws InfrastructureException DB_SAVE_FAILURE
+     */
+    InternalProfileCreateResponse createInternalProfile(InternalProfileCreateRequest request);
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -49,8 +49,10 @@ public interface UserProfileService {
      * 2) Redis에 저장
      * 3) 응답 반환
      *
-     * @param userId 초대 코드 발급자(user)의 도메인 ID
+     * @param userId  X-User-Id 헤더에서 전달받은 유저 도메인 ID
      * @return InviteCodeIssueResponse 발급된 초대 코드 응답 DTO
+     * @throws InfrastructureException INVITE_CODE_GENERATION_FAILURE
+     * @throws InfrastructureException INVITE_CODE_SAVE_FAILURE
      */
     InviteCodeIssueResponse issueInviteCode(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -1,7 +1,10 @@
 package ready_to_marry.userservice.profile.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.common.exception.ValidationException;
 import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateRequest;
+import ready_to_marry.userservice.profile.dto.request.ProfileUpdateRequest;
 import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
 
 /**
@@ -19,4 +22,23 @@ public interface UserProfileService {
      * @throws InfrastructureException DB_SAVE_FAILURE
      */
     InternalProfileCreateResponse createInternalProfile(InternalProfileCreateRequest request);
+
+    /**
+     * 현재 로그인한 유저의 프로필(name, phone, profileImage)을 수정
+     * 전달된 name, phone, profileImage 중 null이 아닌 필드만 업데이트 (null-머지 방식)
+     * 1) 유저 프로필 조회
+     * 2) name 검증 및 수정
+     * 3) phone 검증 및 수정
+     * 4) profileImage 검증 및 업로드
+     * 5) 저장 + 실패 시 S3 롤백 처리
+     *
+     * @param userId  X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request 수정 요청 DTO (name, phone, profileImage 중 일부 또는 전체 포함)
+     * @throws EntityNotFoundException 유저 프로필이 존재하지 않는 경우
+     * @throws ValidationException     name, phone, profileImage 검증에서 적절하지 값이 들어온 경우
+     * @throws InfrastructureException DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException DB_SAVE_FAILURE
+     * @throws InfrastructureException S3_UPLOAD_FAILURE
+     */
+    void updateMyProfile(Long userId, ProfileUpdateRequest request);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -59,7 +59,7 @@ public interface UserProfileService {
     InviteCodeIssueResponse issueInviteCode(Long userId);
 
     /**
-     * 현재 로그인한 유저의 초대 코드 기반으로 커플 연결을 수행
+     * 초대 코드 기반으로 현재 로그인한 유저의 커플 연결 수행
      * 1) 초대 코드로 상대(발급자) userId 조회
      * 2) 자기 자신에게 연결 시도한 경우
      * 3) 유저 프로필 조회 (본인 + 상대방)

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -80,4 +80,20 @@ public interface UserProfileService {
      * @throws InfrastructureException      INVITE_CODE_DELETE_FAILURE
      */
     void connectCouple(Long userId, CoupleConnectRequest request);
+
+    /**
+     *현재 로그인한 유저의 커플 연결 해제
+     * 1) userId로 현재 로그인한 유저의 UserProfile 조회
+     * 2) 본인이 커플 상태(coupleId 존재)인지 확인
+     * 3) 상대방 프로필 조회 (같은 coupleId를 가진 프로필 중 본인이 아닌 상대)
+     * 4) 본인과 상대방의 coupleId를 null로 설정하여 커플 해제
+     * 5) 두 프로필 모두 저장
+     *
+     * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @throws EntityNotFoundException      본인 또는 상대방의 프로필이 존재하지 않는 경우
+     * @throws BusinessException            ALREADY_RELEASED
+     * @throws InfrastructureException      DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException      DB_SAVE_FAILURE
+     */
+    void releaseCouple(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -1,8 +1,10 @@
 package ready_to_marry.userservice.profile.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import ready_to_marry.userservice.common.exception.BusinessException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
 import ready_to_marry.userservice.common.exception.ValidationException;
+import ready_to_marry.userservice.profile.dto.request.CoupleConnectRequest;
 import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateRequest;
 import ready_to_marry.userservice.profile.dto.request.ProfileUpdateRequest;
 import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
@@ -55,4 +57,27 @@ public interface UserProfileService {
      * @throws InfrastructureException INVITE_CODE_SAVE_FAILURE
      */
     InviteCodeIssueResponse issueInviteCode(Long userId);
+
+    /**
+     * 현재 로그인한 유저의 초대 코드 기반으로 커플 연결을 수행
+     * 1) 초대 코드로 상대(발급자) userId 조회
+     * 2) 자기 자신에게 연결 시도한 경우
+     * 3) 유저 프로필 조회 (본인 + 상대방)
+     * 4) 이미 커플 상태인지 확인
+     * 5) coupleId 설정 및 저장
+     * 6) 초대 코드 삭제
+     *
+     * @param userId  X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request 유저의 커플 연결 요청 DTO (inviteCode)
+     * @throws EntityNotFoundException 본인 또는 상대방의 프로필이 존재하지 않는 경우
+     * @throws BusinessException INVALID_INVITE_CODE
+     * @throws BusinessException CANNOT_CONNECT_TO_SELF
+     * @throws BusinessException ALREADY_CONNECTED_SELF
+     * @throws BusinessException ALREADY_CONNECTED_PARTNER
+     * @throws InfrastructureException DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException DB_SAVE_FAILURE
+     * @throws InfrastructureException INVITE_CODE_RETRIEVE_FAILURE
+     * @throws InfrastructureException INVITE_CODE_DELETE_FAILURE
+     */
+    void connectCouple(Long userId, CoupleConnectRequest request);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -6,6 +6,7 @@ import ready_to_marry.userservice.common.exception.ValidationException;
 import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateRequest;
 import ready_to_marry.userservice.profile.dto.request.ProfileUpdateRequest;
 import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
+import ready_to_marry.userservice.profile.dto.response.InviteCodeIssueResponse;
 
 /**
  * 유저 프로필 도메인의 비즈니스 로직을 제공하는 서비스 인터페이스
@@ -41,4 +42,15 @@ public interface UserProfileService {
      * @throws InfrastructureException S3_UPLOAD_FAILURE
      */
     void updateMyProfile(Long userId, ProfileUpdateRequest request);
+
+    /**
+     * 현재 로그인한 유저의 커플 초대 코드 발급
+     * 1) 중복되지 않는 초대코드 생성
+     * 2) Redis에 저장
+     * 3) 응답 반환
+     *
+     * @param userId 초대 코드 발급자(user)의 도메인 ID
+     * @return InviteCodeIssueResponse 발급된 초대 코드 응답 DTO
+     */
+    InviteCodeIssueResponse issueInviteCode(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -20,9 +20,9 @@ public interface UserProfileService {
      * 2) user_profile 테이블에 저장
      * 3) 생성된 userId를 포함한 응답 DTO 반환
      *
-     * @param request name, phone 포함 요청 DTO
-     * @return InternalProfileCreateResponse 생성된 userId 포함 응답 DTO
-     * @throws InfrastructureException DB_SAVE_FAILURE
+     * @param request                           name, phone 포함 요청 DTO
+     * @return InternalProfileCreateResponse    생성된 userId 포함 응답 DTO
+     * @throws InfrastructureException          DB_SAVE_FAILURE
      */
     InternalProfileCreateResponse createInternalProfile(InternalProfileCreateRequest request);
 
@@ -35,13 +35,13 @@ public interface UserProfileService {
      * 4) profileImage 검증 및 업로드
      * 5) 저장 + 실패 시 S3 롤백 처리
      *
-     * @param userId  X-User-Id 헤더에서 전달받은 유저 도메인 ID
-     * @param request 수정 요청 DTO (name, phone, profileImage 중 일부 또는 전체 포함)
-     * @throws EntityNotFoundException 유저 프로필이 존재하지 않는 경우
-     * @throws ValidationException     name, phone, profileImage 검증에서 적절하지 값이 들어온 경우
-     * @throws InfrastructureException DB_RETRIEVE_FAILURE
-     * @throws InfrastructureException DB_SAVE_FAILURE
-     * @throws InfrastructureException S3_UPLOAD_FAILURE
+     * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request                       수정 요청 DTO (name, phone, profileImage 중 일부 또는 전체 포함)
+     * @throws EntityNotFoundException      유저 프로필이 존재하지 않는 경우
+     * @throws ValidationException          name, phone, profileImage 검증에서 적절하지 값이 들어온 경우
+     * @throws InfrastructureException      DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException      DB_SAVE_FAILURE
+     * @throws InfrastructureException      S3_UPLOAD_FAILURE
      */
     void updateMyProfile(Long userId, ProfileUpdateRequest request);
 
@@ -51,10 +51,10 @@ public interface UserProfileService {
      * 2) Redis에 저장
      * 3) 응답 반환
      *
-     * @param userId  X-User-Id 헤더에서 전달받은 유저 도메인 ID
-     * @return InviteCodeIssueResponse 발급된 초대 코드 응답 DTO
-     * @throws InfrastructureException INVITE_CODE_GENERATION_FAILURE
-     * @throws InfrastructureException INVITE_CODE_SAVE_FAILURE
+     * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @return InviteCodeIssueResponse      발급된 초대 코드 응답 DTO
+     * @throws InfrastructureException      INVITE_CODE_GENERATION_FAILURE
+     * @throws InfrastructureException      INVITE_CODE_SAVE_FAILURE
      */
     InviteCodeIssueResponse issueInviteCode(Long userId);
 
@@ -67,17 +67,17 @@ public interface UserProfileService {
      * 5) coupleId 설정 및 저장
      * 6) 초대 코드 삭제
      *
-     * @param userId  X-User-Id 헤더에서 전달받은 유저 도메인 ID
-     * @param request 유저의 커플 연결 요청 DTO (inviteCode)
-     * @throws EntityNotFoundException 본인 또는 상대방의 프로필이 존재하지 않는 경우
-     * @throws BusinessException INVALID_INVITE_CODE
-     * @throws BusinessException CANNOT_CONNECT_TO_SELF
-     * @throws BusinessException ALREADY_CONNECTED_SELF
-     * @throws BusinessException ALREADY_CONNECTED_PARTNER
-     * @throws InfrastructureException DB_RETRIEVE_FAILURE
-     * @throws InfrastructureException DB_SAVE_FAILURE
-     * @throws InfrastructureException INVITE_CODE_RETRIEVE_FAILURE
-     * @throws InfrastructureException INVITE_CODE_DELETE_FAILURE
+     * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request                       유저의 커플 연결 요청 DTO (inviteCode)
+     * @throws EntityNotFoundException      본인 또는 상대방의 프로필이 존재하지 않는 경우
+     * @throws BusinessException            INVALID_INVITE_CODE
+     * @throws BusinessException            CANNOT_CONNECT_TO_SELF
+     * @throws BusinessException            ALREADY_CONNECTED_SELF
+     * @throws BusinessException            ALREADY_CONNECTED_PARTNER
+     * @throws InfrastructureException      DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException      DB_SAVE_FAILURE
+     * @throws InfrastructureException      INVITE_CODE_RETRIEVE_FAILURE
+     * @throws InfrastructureException      INVITE_CODE_DELETE_FAILURE
      */
     void connectCouple(Long userId, CoupleConnectRequest request);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -9,6 +9,7 @@ import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateReque
 import ready_to_marry.userservice.profile.dto.request.ProfileUpdateRequest;
 import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
 import ready_to_marry.userservice.profile.dto.response.InviteCodeIssueResponse;
+import ready_to_marry.userservice.profile.dto.response.UserProfileResponse;
 
 /**
  * 유저 프로필 도메인의 비즈니스 로직을 제공하는 서비스 인터페이스
@@ -25,6 +26,19 @@ public interface UserProfileService {
      * @throws InfrastructureException          DB_SAVE_FAILURE
      */
     InternalProfileCreateResponse createInternalProfile(InternalProfileCreateRequest request);
+
+    /**
+     * 로그인한 유저의 프로필 정보 조회
+     * 1) 유저 프로필 조회
+     * 2) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부를 포함한 응답 DTO 반환
+     *
+     * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @return UserProfileResponse          프로필 조회 결과 응답 DTO (유저 프로필 정보 및 커플 연결 여부 포함)
+     * @throws EntityNotFoundException      유저 프로필이 존재하지 않는 경우
+     * @throws InfrastructureException      DB_RETRIEVE_FAILURE
+     */
+    UserProfileResponse getMyProfile(Long userId);
+
 
     /**
      * 현재 로그인한 유저의 프로필(name, phone, profileImage)을 수정

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
@@ -1,23 +1,31 @@
 package ready_to_marry.userservice.profile.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import ready_to_marry.userservice.common.exception.ErrorCode;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.common.exception.ValidationException;
 import ready_to_marry.userservice.common.util.MaskingUtils;
 import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateRequest;
+import ready_to_marry.userservice.profile.dto.request.ProfileUpdateRequest;
 import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
 import ready_to_marry.userservice.profile.entity.UserProfile;
 import ready_to_marry.userservice.profile.repository.UserProfileRepository;
+import ready_to_marry.userservice.profile.util.S3Storage;
+
+import java.io.IOException;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserProfileServiceImpl implements UserProfileService {
     private final UserProfileRepository userProfileRepository;
+    private final S3Storage s3Storage;
 
     @Override
     @Transactional
@@ -41,5 +49,91 @@ public class UserProfileServiceImpl implements UserProfileService {
         return InternalProfileCreateResponse.builder()
                 .userId(savedUserProfile.getUserId())
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateMyProfile(Long userId, ProfileUpdateRequest request) {
+        // 1) 유저 프로필 조회
+        UserProfile profile;
+        try {
+            profile = userProfileRepository.findById(userId)
+                    .orElseThrow(() -> {
+                        log.error("User profile not found: identifierType=userId, identifierValue={}", MaskingUtils.maskUserId(userId));
+                        return new EntityNotFoundException("User profile not found");
+                    });
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 2) name 검증 및 수정
+        String name = request.getName();
+        if (name != null) {
+            if (name.isBlank() || name.length() > 50) {
+                throw new ValidationException("name", "must be 1~50 characters and not blank");
+            }
+            profile.setName(name);
+        }
+
+        // 3) phone 검증 및 수정
+        String phone = request.getPhone();
+        if (phone != null) {
+            if (!phone.matches("^\\+?[0-9\\-]{1,20}$")) {
+                throw new ValidationException("phone", "Invalid phone number format");
+            }
+            profile.setPhone(phone);
+        }
+
+        // 4) profileImage 검증 및 업로드
+        MultipartFile imageFile = request.getProfileImage();
+        String uploadedImageUrl = null;
+
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String contentType = imageFile.getContentType();
+            if (contentType == null || !contentType.startsWith("image/")) {
+                throw new ValidationException("profileImage", "Only image files are allowed");
+            }
+
+            // 새 이미지 업로드
+            try {
+                uploadedImageUrl = s3Storage.upload(imageFile, "user-profile-images");
+            } catch (IOException ex) {
+                log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.S3_UPLOAD_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+                throw new InfrastructureException(ErrorCode.S3_UPLOAD_FAILURE, ex);
+            }
+
+            // 기존 이미지 삭제 (업로드 성공 후)
+            String oldImageUrl = profile.getProfileImgUrl();
+            if (oldImageUrl != null && !oldImageUrl.isBlank()) {
+                try {
+                    s3Storage.delete(oldImageUrl);
+                } catch (Exception ex) {
+                    log.warn("System error occurred while deleting old image: imageUrl={}", oldImageUrl, ex);
+                }
+            }
+
+            // 새로운 이미지 URL 설정
+            profile.setProfileImgUrl(uploadedImageUrl);
+        }
+
+        // 5) 저장 + 실패 시 S3 롤백 처리
+        try {
+            userProfileRepository.save(profile);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+
+            // S3에 올렸던 이미지 삭제 (rollback)
+            if (uploadedImageUrl != null) {
+                try {
+                    s3Storage.delete(uploadedImageUrl);
+                    log.info("Rolled back uploaded image from S3: imageUrl={}", uploadedImageUrl);
+                } catch (Exception deleteEx) {
+                    log.warn("System error occurred while deleting image from S3 after DB failure: imageUrl={}", uploadedImageUrl, deleteEx);
+                }
+            }
+
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
     }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
@@ -3,7 +3,7 @@ package ready_to_marry.userservice.profile.service;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
@@ -1,0 +1,45 @@
+package ready_to_marry.userservice.profile.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ready_to_marry.userservice.common.exception.ErrorCode;
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.common.util.MaskingUtils;
+import ready_to_marry.userservice.profile.dto.request.InternalProfileCreateRequest;
+import ready_to_marry.userservice.profile.dto.response.InternalProfileCreateResponse;
+import ready_to_marry.userservice.profile.entity.UserProfile;
+import ready_to_marry.userservice.profile.repository.UserProfileRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserProfileServiceImpl implements UserProfileService {
+    private final UserProfileRepository userProfileRepository;
+
+    @Override
+    @Transactional
+    public InternalProfileCreateResponse createInternalProfile(InternalProfileCreateRequest request) {
+        // 1) 전달받은 name, phone 값으로 UserProfile 엔티티 생성
+        UserProfile profile = UserProfile.builder()
+                .name(request.getName())
+                .phone(request.getPhone())
+                .build();
+
+        UserProfile savedUserProfile;
+        try {
+            // 2) user_profile 테이블에 저장
+            savedUserProfile = userProfileRepository.save(profile);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=phone, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskPhone(request.getPhone()), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+
+        // 3) 생성된 userId를 포함한 응답 DTO 반환
+        return InternalProfileCreateResponse.builder()
+                .userId(savedUserProfile.getUserId())
+                .build();
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/util/S3Storage.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/util/S3Storage.java
@@ -1,0 +1,106 @@
+package ready_to_marry.userservice.profile.util;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import ready_to_marry.userservice.profile.config.S3Properties;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * S3 파일 저장 및 삭제 기능을 제공하는 유틸리티 컴포넌트
+ */
+@Component
+@RequiredArgsConstructor
+public class S3Storage {
+    private final S3Properties s3Properties;
+    private S3Client s3Client;
+
+    @PostConstruct
+    public void init() {
+         this.s3Client = S3Client.builder()
+                .region(Region.of(s3Properties.getRegion().getStaticRegion()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        s3Properties.getCredentials().getAccessKey(),
+                                        s3Properties.getCredentials().getSecretKey()
+                                )
+                        )
+                )
+                .build();
+    }
+
+    /**
+     * S3에 이미지 업로드
+     *
+     * @param multipartFile 업로드할 이미지 파일
+     * @param dir           업로드할 S3 디렉토리
+     * @return 업로드된 이미지의 public URL
+     * @throws IOException 업로드 실패 시
+     */
+    public String upload(MultipartFile multipartFile, String dir) throws IOException {
+        String extension = getFileExtension(multipartFile.getOriginalFilename());
+        String fileName = dir + "/" + UUID.randomUUID() + "_" +
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + extension;
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(s3Properties.getS3().getBucket())
+                .key(fileName)
+                .contentType(multipartFile.getContentType())
+                .acl(ObjectCannedACL.PUBLIC_READ)
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromInputStream(
+                multipartFile.getInputStream(),
+                multipartFile.getSize()
+        ));
+
+        return getFileUrl(fileName);
+    }
+
+    /**
+     * S3에서 파일 삭제
+     *
+     * @param fileUrl 전체 public URL
+     */
+    public void delete(String fileUrl) {
+        String key = extractKeyFromUrl(fileUrl);
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(s3Properties.getS3().getBucket())
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(request);
+    }
+
+    private String getFileUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                s3Properties.getS3().getBucket(),
+                s3Properties.getRegion().getStaticRegion(),
+                key
+        );
+    }
+
+    private String getFileExtension(String filename) {
+        return (filename != null && filename.contains("."))
+                ? filename.substring(filename.lastIndexOf("."))
+                : "";
+    }
+
+    private String extractKeyFromUrl(String fileUrl) {
+        return fileUrl.substring(fileUrl.indexOf(".com/") + 5);
+    }
+}


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 유저 프로필 생성·조회·수정 기능을 비롯해 S3 이미지 업로드/삭제, Redis 기반 초대 코드 발급·검증, 커플 연결 및 해제 로직을 추가했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- UserProfile 엔티티 & 레포지토리
  - `UserProfile` 엔티티 추가: 사용자 테이블 구조 매핑 (UUID 기반 커플 ID 포함)
  - `UserProfileRepository` 추가 및 확장: 기본 CRUD, `findByCoupleId(UUID)` 메서드 선언

- 프로필 등록 (Internal API)
  - DTO: `InternalProfileCreateRequest` / `InternalProfileCreateResponse`
  - 컨트롤러: `/internal/user-profiles` POST 엔드포인트 (`UserProfileInternalController`)
  - 서비스: `createInternalProfile` 구현 

- **검증 예외 & 공통 예외 처리 강화**
  - `ValidationException` 추가: 서비스 로직 내부에서 발생하는 단일 필드 검증 실패 시 사용
  - `GlobalExceptionHandler.handleValidation`에 `ValidationException` 핸들링 로직 추가
  - `ErrorCode`에 비즈니스 오류 및 인프라 오류 코드 확장

- **S3 이미지 업로드/삭제 지원**
  - 설정 바인딩: `S3Properties` (버킷, 리전, 자격 증명)
  - 컴포넌트: `S3Storage`
    - `upload(MultipartFile, String)`: 파일 업로드 후 퍼블릭 URL 반환
    - `delete(String)`: S3 객체 삭제

- **프로필 수정 기능**
  - DTO: `ProfileUpdateRequest` 
  - 컨트롤러: `/users/me/profiles` PATCH 엔드포인트 (`UserProfileController`)
  - 서비스: `updateMyProfile`
    - null-머지 방식으로 제공된 필드만 업데이트

- **Redis & Retry 설정 및 초대 코드 기능**
  - `InviteCodeProperties`: TTL 설정 바인딩
  - `InviteCodeRepository` 인터페이스 + `RedisInviteCodeRepository` 구현
  - `InviteCodeService` + `InviteCodeServiceImpl`: Redis 작업에 @Retryable 적용

- **초대 코드 발급**
  - DTO: `InviteCodeIssueResponse`
  - 컨트롤러: `/users/me/invite-code` POST 엔드포인트 (`UserInviteController` → 리팩토링 후 `UserCoupleController`)
  - 서비스: `issueInviteCode`

- **커플 연결/해제 기능**
  - DTO: `CoupleConnectRequest`
  - 컨트롤러:
    - `/users/me/couple-connection` POST: 초대 코드 기반으로 커플 연결 (`UserCoupleController`)
    - `/users/me/couple-connection/release` POST: 커플 연결 해제 (`UserCoupleController`)
  - 서비스:
    - `connectCouple(Long userId, CoupleConnectRequest request)`
    - `releaseCouple(Long userId)`

- **프로필 조회 기능**
  - DTO: `UserProfileResponse`
  - 컨트롤러: `/users/me/profiles` GET 엔드포인트 (`UserProfileController`)
  - 서비스: `getMyProfile(Long userId)`

- **의존성 및 마스킹 유틸 추가/수정**
  - `build.gradle`:
    - Apache Commons Lang3 추가
    - Spring Retry, AOP, Redis, AWS SDK for S3 추가
  - `MaskingUtils` 확장:
    - `maskPhone`, `maskUserId`, `maskInviteCode`, `maskCoupleId` 구현

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)