### PR TITLE
Feat/couple budget: 커플 지출 관리 기능 추가

### DIFF
--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -2,14 +2,20 @@ package ready_to_marry.userservice.budget.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetUpdateRequest;
+import ready_to_marry.userservice.budget.dto.response.CoupleBudgetDetailResponse;
 import ready_to_marry.userservice.budget.dto.response.CoupleBudgetSummaryResponse;
 import ready_to_marry.userservice.budget.service.CoupleBudgetService;
+import ready_to_marry.userservice.common.dto.request.PagingRequest;
 import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.common.dto.response.Meta;
+
+import java.util.List;
 
 /**
  * 유저의 커플 지출 관련 기능을 처리하는 컨트롤러
@@ -133,6 +139,32 @@ public class CoupleBudgetController {
                 .code(0)
                 .message("Couple budget summary retrieved successfully")
                 .data(budgetSummary)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 커플 지출 내역을 지출 날짜 기준으로 내림차순 페이징 조회
+     *
+     * @param userId        게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param pagingRequest 페이징 요청 정보 (page, size)
+     * @return 성공 시 code=0, data=커플 지출 내역 페이징 결과 정보
+     */
+    @GetMapping("/details")
+    public ResponseEntity<ApiResponse<List<CoupleBudgetDetailResponse>>> getBudgetDetailList(@RequestHeader("X-User-Id") Long userId, @ModelAttribute PagingRequest pagingRequest) {
+        Page<CoupleBudgetDetailResponse> page = coupleBudgetService.getBudgetDetailList(userId, pagingRequest);
+
+        ApiResponse<List<CoupleBudgetDetailResponse>> response = ApiResponse.<List<CoupleBudgetDetailResponse>>builder()
+                .code(0)
+                .message("Budget detail list retrieved successfully")
+                .data(page.getContent())
+                .meta(Meta.builder()
+                        .page(page.getNumber())
+                        .size(page.getSize())
+                        .totalElements(page.getTotalElements())
+                        .totalPages(page.getTotalPages())
+                        .build())
                 .build();
 
         return ResponseEntity.ok(response);

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -1,0 +1,39 @@
+package ready_to_marry.userservice.budget.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
+import ready_to_marry.userservice.budget.service.CoupleBudgetService;
+import ready_to_marry.userservice.common.dto.response.ApiResponse;
+
+/**
+ * 유저의 커플 지출 관련 기능을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/users/me/budgets")
+@RequiredArgsConstructor
+public class CoupleBudgetController {
+    private final CoupleBudgetService coupleBudgetService;
+
+    /**
+     * 커플 총 예산 등록
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param request 총 예산 등록 요청 정보
+     * @return 성공 시 code=0, data=null
+     */
+    @PostMapping("/total-budget")
+    public ResponseEntity<ApiResponse<Void>> createTotalBudget(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody TotalBudgetCreateRequest request) {
+        coupleBudgetService.createTotalBudget(userId, request);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("Total budget created successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -152,7 +152,7 @@ public class CoupleBudgetController {
      * @return 성공 시 code=0, data=커플 지출 내역 페이징 결과 정보
      */
     @GetMapping("/details")
-    public ResponseEntity<ApiResponse<List<CoupleBudgetDetailResponse>>> getBudgetDetailList(@RequestHeader("X-User-Id") Long userId, @ModelAttribute PagingRequest pagingRequest) {
+    public ResponseEntity<ApiResponse<List<CoupleBudgetDetailResponse>>> getBudgetDetailList(@RequestHeader("X-User-Id") Long userId, @Valid @ModelAttribute PagingRequest pagingRequest) {
         Page<CoupleBudgetDetailResponse> page = coupleBudgetService.getBudgetDetailList(userId, pagingRequest);
 
         ApiResponse<List<CoupleBudgetDetailResponse>> response = ApiResponse.<List<CoupleBudgetDetailResponse>>builder()

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
+import ready_to_marry.userservice.budget.dto.request.TotalBudgetUpdateRequest;
 import ready_to_marry.userservice.budget.service.CoupleBudgetService;
 import ready_to_marry.userservice.common.dto.response.ApiResponse;
 
@@ -72,6 +73,26 @@ public class CoupleBudgetController {
         ApiResponse<Void> response = ApiResponse.<Void>builder()
                 .code(0)
                 .message("Budget detail deleted successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 커플 총 예산 수정
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param request 총 예산 수정 요청 정보
+     * @return 성공 시 code=0, data=null
+     */
+    @PatchMapping("/total-budget")
+    public ResponseEntity<ApiResponse<Void>> updateTotalBudget(@RequestHeader("X-User-Id") Long userId, @RequestBody @Valid TotalBudgetUpdateRequest request) {
+        coupleBudgetService.updateTotalBudget(userId, request);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("Total budget updated successfully")
                 .data(null)
                 .build();
 

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -57,4 +57,24 @@ public class CoupleBudgetController {
 
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 커플 지출 내역 삭제
+     *
+     * @param userId         게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param budgetDetailId 지출 내역 ID
+     * @return 성공 시 code=0, data=null
+     */
+    @DeleteMapping("/details/{budgetDetailId}")
+    public ResponseEntity<ApiResponse<Void>> deleteBudgetDetail(@RequestHeader("X-User-Id") Long userId, @PathVariable Long budgetDetailId) {
+        coupleBudgetService.deleteBudgetDetail(userId, budgetDetailId);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("Budget detail deleted successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
 import ready_to_marry.userservice.budget.service.CoupleBudgetService;
 import ready_to_marry.userservice.common.dto.response.ApiResponse;
@@ -31,6 +32,26 @@ public class CoupleBudgetController {
         ApiResponse<Void> response = ApiResponse.<Void>builder()
                 .code(0)
                 .message("Total budget created successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 커플 지출 내역 등록
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param request 지출 내역 등록 요청 정보
+     * @return 성공 시 code=0, data=null
+     */
+    @PostMapping("/details")
+    public ResponseEntity<ApiResponse<Void>> createBudgetDetail(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody BudgetDetailCreateRequest request) {
+        coupleBudgetService.createBudgetDetail(userId, request);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("Budget detail created successfully")
                 .data(null)
                 .build();
 

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -98,4 +98,23 @@ public class CoupleBudgetController {
 
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 커플 총 예산 삭제
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @return 성공 시 code=0, data=null
+     */
+    @DeleteMapping("/total-budget")
+    public ResponseEntity<ApiResponse<Void>> deleteTotalBudget(@RequestHeader("X-User-Id") Long userId) {
+        coupleBudgetService.deleteTotalBudget(userId);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("Total budget deleted successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/controller/CoupleBudgetController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetUpdateRequest;
+import ready_to_marry.userservice.budget.dto.response.CoupleBudgetSummaryResponse;
 import ready_to_marry.userservice.budget.service.CoupleBudgetService;
 import ready_to_marry.userservice.common.dto.response.ApiResponse;
 
@@ -113,6 +114,25 @@ public class CoupleBudgetController {
                 .code(0)
                 .message("Total budget deleted successfully")
                 .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 커플 지출 요약 내역 조회
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @return 성공 시 code=0, data=커플 지출 요약 내역 정보
+     */
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResponse<CoupleBudgetSummaryResponse>> getBudgetSummary(@RequestHeader("X-User-Id") Long userId) {
+        CoupleBudgetSummaryResponse budgetSummary = coupleBudgetService.getBudgetSummary(userId);
+
+        ApiResponse<CoupleBudgetSummaryResponse> response = ApiResponse.<CoupleBudgetSummaryResponse>builder()
+                .code(0)
+                .message("Couple budget summary retrieved successfully")
+                .data(budgetSummary)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/dto/request/BudgetDetailCreateRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/dto/request/BudgetDetailCreateRequest.java
@@ -1,0 +1,38 @@
+package ready_to_marry.userservice.budget.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import ready_to_marry.userservice.budget.enums.BudgetCategory;
+
+import java.time.LocalDate;
+
+/**
+ * 커플의 지출 내역 등록 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BudgetDetailCreateRequest {
+    // 지출 카테고리 (HALL, SDM, CEREMONY, SUPPLIES, ETC)
+    @NotNull
+    private BudgetCategory category;
+
+    // 지출 금액
+    @NotNull
+    @Min(0)
+    private Long spentAmount;
+
+    // 지출 날짜
+    @NotNull
+    private LocalDate date;
+
+    // 지출 내용
+    @NotBlank
+    @Size(max = 500)
+    private String content;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/dto/request/TotalBudgetCreateRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/dto/request/TotalBudgetCreateRequest.java
@@ -1,0 +1,20 @@
+package ready_to_marry.userservice.budget.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+/**
+ * 커플의 총 예산 등록 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TotalBudgetCreateRequest {
+    // 총 예산
+    @NotNull
+    @Min(0)
+    private Long totalBudget;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/dto/request/TotalBudgetUpdateRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/dto/request/TotalBudgetUpdateRequest.java
@@ -1,0 +1,20 @@
+package ready_to_marry.userservice.budget.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+/**
+ * 커플의 총 예산 수정 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TotalBudgetUpdateRequest {
+    // 총 예산
+    @NotNull
+    @Min(0)
+    private Long totalBudget;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/dto/response/CoupleBudgetDetailResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/dto/response/CoupleBudgetDetailResponse.java
@@ -1,0 +1,31 @@
+package ready_to_marry.userservice.budget.dto.response;
+
+import lombok.*;
+import ready_to_marry.userservice.budget.enums.BudgetCategory;
+
+import java.time.LocalDate;
+
+/**
+ * 로그인한 유저의 커플 지출 내역 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CoupleBudgetDetailResponse {
+    // 지출 내역 ID
+    private Long budgetDetailId;
+
+    // 지출 카테고리
+    private BudgetCategory category;
+
+    // 지출 금액
+    private Long spentAmount;
+
+    // 지출 날짜
+    private LocalDate date;
+
+    // 지출 내용
+    private String content;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/dto/response/CoupleBudgetSummaryResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/dto/response/CoupleBudgetSummaryResponse.java
@@ -1,0 +1,37 @@
+package ready_to_marry.userservice.budget.dto.response;
+
+import lombok.*;
+
+/**
+ * 로그인한 유저의 커플 지출 요약 내역 조회 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CoupleBudgetSummaryResponse {
+    // 총 예산
+    private Long totalBudget;
+
+    // 총 지출 금액
+    private Long totalSpent;
+
+    // 남은 예산
+    private Long remainingBudget;
+
+    // 웨딩홀 총 지출 금액
+    private Long hallSpent;
+
+    // 스드메 총 지출 금액
+    private Long sdmSpent;
+
+    // 본식 총 지출 금액
+    private Long ceremonySpent;
+
+    // 혼수 총 지출 금액
+    private Long suppliesSpent;
+
+    // 기타 총 지출 금액
+    private Long etcSpent;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/entity/CoupleBudgetDetail.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/entity/CoupleBudgetDetail.java
@@ -1,0 +1,47 @@
+package ready_to_marry.userservice.budget.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import ready_to_marry.userservice.budget.enums.BudgetCategory;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * user_db.couple_budget_detail 테이블 매핑 엔티티
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "couple_budget_detail")
+public class CoupleBudgetDetail {
+    // 지출 내역 ID
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "budget_detail_id", updatable = false, nullable = false)
+    private Long budgetDetailId;
+
+    // 커플 ID (외래 키)
+    @Column(name = "couple_id", nullable = false)
+    private UUID coupleId;
+
+    // 지출 카테고리
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 20)
+    private BudgetCategory category;
+
+    // 지출 금액
+    @Column(name = "spent_amount", nullable = false)
+    private Long spentAmount;
+
+    // 지출 날짜
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    // 지출 내용
+    @Column(name = "content", nullable = false, length = 500)
+    private String content;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/entity/CoupleBudgetSummary.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/entity/CoupleBudgetSummary.java
@@ -1,0 +1,60 @@
+package ready_to_marry.userservice.budget.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+/**
+ * user_db.couple_budget_summary 테이블 매핑 엔티티
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "couple_budget_summary")
+public class CoupleBudgetSummary {
+    // 지출 요약 내역 ID
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "budget_summary_id", updatable = false, nullable = false)
+    private Long budgetSummaryId;
+
+    // 커플 ID (외래 키)
+    @Column(name = "couple_id", nullable = false, unique = true)
+    private UUID coupleId;
+
+    // 총 예산 (default = 0)
+    @Column(name = "total_budget", nullable = false)
+    private Long totalBudget;
+
+    // 총 지출 금액 (hall_spent + sdm_spent + ceremony_spent + supplies_spent + etc_spent)
+    @Column(name = "total_spent", nullable = false)
+    private Long totalSpent;
+
+    // 남은 예산 (total_budget - total_spent)
+    @Column(name = "remaining_budget", nullable = false)
+    private Long remainingBudget;
+
+    // 웨딩홀 총 지출 금액 (default = 0)
+    @Column(name = "hall_spent", nullable = false)
+    private Long hallSpent;
+
+    // 스드메 총 지출 금액 (default = 0)
+    @Column(name = "sdm_spent", nullable = false)
+    private Long sdmSpent;
+
+    // 본식 총 지출 금액 (default = 0)
+    @Column(name = "ceremony_spent", nullable = false)
+    private Long ceremonySpent;
+
+    // 혼수 총 지출 금액 (default = 0)
+    @Column(name = "supplies_spent", nullable = false)
+    private Long suppliesSpent;
+
+    // 기타 총 지출 금액 (default = 0)
+    @Column(name = "etc_spent", nullable = false)
+    private Long etcSpent;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/entity/CoupleBudgetSummary.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/entity/CoupleBudgetSummary.java
@@ -26,8 +26,8 @@ public class CoupleBudgetSummary {
     @Column(name = "couple_id", nullable = false, unique = true)
     private UUID coupleId;
 
-    // 총 예산 (default = 0)
-    @Column(name = "total_budget", nullable = false)
+    // 총 예산
+    @Column(name = "total_budget")
     private Long totalBudget;
 
     // 총 지출 금액 (hall_spent + sdm_spent + ceremony_spent + supplies_spent + etc_spent)
@@ -35,7 +35,7 @@ public class CoupleBudgetSummary {
     private Long totalSpent;
 
     // 남은 예산 (total_budget - total_spent)
-    @Column(name = "remaining_budget", nullable = false)
+    @Column(name = "remaining_budget")
     private Long remainingBudget;
 
     // 웨딩홀 총 지출 금액 (default = 0)

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/enums/BudgetCategory.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/enums/BudgetCategory.java
@@ -1,0 +1,9 @@
+package ready_to_marry.userservice.budget.enums;
+
+public enum BudgetCategory {
+    HALL,      // 웨딩홀
+    SDM,       // 스드메
+    CEREMONY,  // 본식
+    SUPPLIES,  // 혼수
+    ETC        // 기타
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetDetailRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetDetailRepository.java
@@ -1,11 +1,23 @@
 package ready_to_marry.userservice.budget.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ready_to_marry.userservice.budget.entity.CoupleBudgetDetail;
+import ready_to_marry.userservice.budget.repository.projection.CoupleBudgetDetailProjection;
+
+import java.util.UUID;
 
 /**
  * CoupleBudgetDetail CRUD 및 조회용 레포지토리
  */
 public interface CoupleBudgetDetailRepository extends JpaRepository<CoupleBudgetDetail, Long> {
-
+    /**
+     * 특정 커플의 지출 내역을 지출 날짜 내림차순으로 페이징 조회
+     *
+     * @param coupleId      커플 ID
+     * @param pageable      페이징 정보
+     * @return 해당 커플의 지출 내역을 지출 날짜 내림차순으로 정렬한 페이징 결과
+     */
+    Page<CoupleBudgetDetailProjection> findByCoupleIdOrderByDateDesc(UUID coupleId, Pageable pageable);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetDetailRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetDetailRepository.java
@@ -1,0 +1,11 @@
+package ready_to_marry.userservice.budget.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ready_to_marry.userservice.budget.entity.CoupleBudgetDetail;
+
+/**
+ * CoupleBudgetDetail CRUD 및 조회용 레포지토리
+ */
+public interface CoupleBudgetDetailRepository extends JpaRepository<CoupleBudgetDetail, Long> {
+
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetSummaryRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetSummaryRepository.java
@@ -1,0 +1,11 @@
+package ready_to_marry.userservice.budget.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ready_to_marry.userservice.budget.entity.CoupleBudgetSummary;
+
+/**
+ * CoupleBudgetSummary CRUD 및 조회용 레포지토리
+ */
+public interface CoupleBudgetSummaryRepository extends JpaRepository<CoupleBudgetSummary, Long> {
+
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetSummaryRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/repository/CoupleBudgetSummaryRepository.java
@@ -3,9 +3,18 @@ package ready_to_marry.userservice.budget.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ready_to_marry.userservice.budget.entity.CoupleBudgetSummary;
 
+import java.util.Optional;
+import java.util.UUID;
+
 /**
  * CoupleBudgetSummary CRUD 및 조회용 레포지토리
  */
 public interface CoupleBudgetSummaryRepository extends JpaRepository<CoupleBudgetSummary, Long> {
-
+    /**
+     * 특정 커플의 지출 요약 내역 조회
+     *
+     * @param coupleId 유저의 커플 ID
+     * @return 커플 ID에 해당하는 CoupleBudgetSummary Optional
+     */
+    Optional<CoupleBudgetSummary> findByCoupleId(UUID coupleId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/repository/projection/CoupleBudgetDetailProjection.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/repository/projection/CoupleBudgetDetailProjection.java
@@ -1,0 +1,25 @@
+package ready_to_marry.userservice.budget.repository.projection;
+
+import ready_to_marry.userservice.budget.enums.BudgetCategory;
+
+import java.time.LocalDate;
+
+/**
+ * 커플 지출 내역 Projection (엔티티 대신 필드만 조회)
+ */
+public interface CoupleBudgetDetailProjection {
+    // 지출 내역 ID
+    Long getBudgetDetailId();
+
+    // 지출 카테고리
+    BudgetCategory getCategory();
+
+    // 지출 금액
+    Long getSpentAmount();
+
+    // 지출 날짜
+    LocalDate getDate();
+
+    // 지출 내용
+    String getContent();
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -1,6 +1,7 @@
 package ready_to_marry.userservice.budget.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
 import ready_to_marry.userservice.common.exception.BusinessException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
@@ -28,4 +29,25 @@ public interface CoupleBudgetService {
      * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void createTotalBudget(Long userId, TotalBudgetCreateRequest request);
+
+    /**
+     * 유저 ID 기준으로 해당 커플의 지출 내역 등록
+     * 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+     * 2) 지출 내역 생성
+     * 3) 지출 내역 저장
+     * 4) 해당 커플 ID의 커플 지출 요약 내역이 이미 존재하는지 검증
+     * 4-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+     * 4-1-1) 총 예산이 이미 등록된 경우
+     * 4-1-2) 총 예산이 등록되지 않은 경우
+     * 4-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+     * 5) 지출 요약 내역 저장
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request                   유저의 커플 지출 내역 등록 요청 DTO
+     * @throws EntityNotFoundException  본인의 프로필이 존재하지 않는 경우
+     * @throws BusinessException        COUPLE_NOT_CONNECTED
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
+     */
+    void createBudgetDetail(Long userId, BudgetDetailCreateRequest request);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -1,10 +1,13 @@
 package ready_to_marry.userservice.budget.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.data.domain.Page;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetUpdateRequest;
+import ready_to_marry.userservice.budget.dto.response.CoupleBudgetDetailResponse;
 import ready_to_marry.userservice.budget.dto.response.CoupleBudgetSummaryResponse;
+import ready_to_marry.userservice.common.dto.request.PagingRequest;
 import ready_to_marry.userservice.common.exception.BusinessException;
 import ready_to_marry.userservice.common.exception.ForbiddenException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
@@ -132,4 +135,20 @@ public interface CoupleBudgetService {
      * @throws InfrastructureException      DB_RETRIEVE_FAILURE
      */
     CoupleBudgetSummaryResponse getBudgetSummary(Long userId);
+
+    /**
+     * 유저 ID 기준으로 해당 커플의 지출 내역을 지출 날짜 기준으로 내림차순 페이징 조회
+     * 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+     * 2) 페이징 요청 정보 생성
+     * 3) 커플 지출 내역을 지출 날짜 기준으로 내림차순 정렬하여 조회 (Projection 기반)
+     * 4) 조회된 Projection 데이터를 DTO로 매핑하여 반환
+     *
+     * @param userId                            현재 로그인한 유저의 ID
+     * @param pagingRequest                     페이징 요청 정보 (page, size)
+     * @return Page<CoupleBudgetDetailResponse> 커플 지출 내역 페이징 결과
+     * @throws EntityNotFoundException          본인의 프로필이 존재하지 않는 경우
+     * @throws BusinessException                COUPLE_NOT_CONNECTED
+     * @throws InfrastructureException          DB_RETRIEVE_FAILURE
+     */
+    Page<CoupleBudgetDetailResponse> getBudgetDetailList(Long userId, PagingRequest pagingRequest);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -1,0 +1,31 @@
+package ready_to_marry.userservice.budget.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
+import ready_to_marry.userservice.common.exception.BusinessException;
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+
+/**
+ * 커플 지출 도메인의 비즈니스 로직을 제공하는 서비스 인터페이스
+ */
+public interface CoupleBudgetService {
+    /**
+     * 유저 ID 기준으로 해당 커플의 총 예산 등록
+     * 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+     * 2) 해당 커플 ID의 커플 지출 요약 내역이 이미 존재하는지 검증
+     * 2-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+     * 2-1-1) 총 예산이 이미 등록된 경우
+     * 2-1-2) 총 예산이 등록되지 않은 경우
+     * 2-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+     * 3) 저장
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request                   유저의 커플 총 예산 등록 요청 DTO
+     * @throws EntityNotFoundException  본인의 프로필이 존재하지 않는 경우
+     * @throws BusinessException        COUPLE_NOT_CONNECTED
+     * @throws BusinessException        TOTAL_BUDGET_ALREADY_EXISTS
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
+     */
+    void createTotalBudget(Long userId, TotalBudgetCreateRequest request);
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -3,6 +3,7 @@ package ready_to_marry.userservice.budget.service;
 import jakarta.persistence.EntityNotFoundException;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
+import ready_to_marry.userservice.budget.dto.request.TotalBudgetUpdateRequest;
 import ready_to_marry.userservice.common.exception.BusinessException;
 import ready_to_marry.userservice.common.exception.ForbiddenException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
@@ -74,4 +75,25 @@ public interface CoupleBudgetService {
      * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void deleteBudgetDetail(Long userId, Long budgetDetailId);
+
+    /**
+     * 유저 ID 기준으로 해당 커플의 총 예산 수정
+     * 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+     * 2) 해당 커플 ID의 커플 지출 요약 내역이 존재하고, 이미 등록한 총 예산이 존재하는지 검증
+     * 2-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+     * 2-1-1) 총 예산이 이미 등록된 경우
+     * 2-1-2) 총 예산이 등록되지 않은 경우
+     * 2-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+     * 3) 저장
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request                   유저의 커플 총 예산 수정 요청 DTO
+     * @throws EntityNotFoundException  본인의 프로필이 존재하지 않는 경우
+     * @throws EntityNotFoundException  해당 coupleId의 커플 지출 요약 내역이 존재하지 않는 경우
+     * @throws BusinessException        COUPLE_NOT_CONNECTED
+     * @throws BusinessException        TOTAL_BUDGET_NOT_REGISTERED
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
+     */
+    void updateTotalBudget(Long userId, TotalBudgetUpdateRequest request);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetUpdateRequest;
+import ready_to_marry.userservice.budget.dto.response.CoupleBudgetSummaryResponse;
 import ready_to_marry.userservice.common.exception.BusinessException;
 import ready_to_marry.userservice.common.exception.ForbiddenException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
@@ -116,4 +117,18 @@ public interface CoupleBudgetService {
      * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void deleteTotalBudget(Long userId);
+
+    /**
+     * 유저 ID 기준으로 해당 커플의 지출 요약 내역 조회
+     * 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+     * 2) 해당 커플의 지출 요약 내역 조회
+     * 3) 조회된 커플 지출 요약 내역을 응답 DTO로 매핑하여 반환
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @throws EntityNotFoundException  본인의 프로필이 존재하지 않는 경우
+     * @throws EntityNotFoundException  해당 coupleId의 커플 지출 요약 내역이 존재하지 않는 경우
+     * @throws BusinessException        COUPLE_NOT_CONNECTED
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     */
+    CoupleBudgetSummaryResponse getBudgetSummary(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -96,4 +96,24 @@ public interface CoupleBudgetService {
      * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void updateTotalBudget(Long userId, TotalBudgetUpdateRequest request);
+
+    /**
+     * 유저 ID 기준으로 해당 커플의 총 예산 삭제
+     * 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+     * 2) 해당 커플 ID의 커플 지출 요약 내역이 존재하고, 이미 등록한 총 예산이 존재하는지 검증
+     * 2-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+     * 2-1-1) 총 예산이 이미 등록된 경우
+     * 2-1-2) 총 예산이 등록되지 않은 경우
+     * 2-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+     * 3) 저장
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @throws EntityNotFoundException  본인의 프로필이 존재하지 않는 경우
+     * @throws EntityNotFoundException  해당 coupleId의 커플 지출 요약 내역이 존재하지 않는 경우
+     * @throws BusinessException        COUPLE_NOT_CONNECTED
+     * @throws BusinessException        TOTAL_BUDGET_NOT_REGISTERED
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
+     */
+    void deleteTotalBudget(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -124,11 +124,12 @@ public interface CoupleBudgetService {
      * 2) 해당 커플의 지출 요약 내역 조회
      * 3) 조회된 커플 지출 요약 내역을 응답 DTO로 매핑하여 반환
      *
-     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
-     * @throws EntityNotFoundException  본인의 프로필이 존재하지 않는 경우
-     * @throws EntityNotFoundException  해당 coupleId의 커플 지출 요약 내역이 존재하지 않는 경우
-     * @throws BusinessException        COUPLE_NOT_CONNECTED
-     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @return CoupleBudgetSummaryResponse  커플 지출 요약 내역 조회 결과 응답 DTO
+     * @throws EntityNotFoundException      본인의 프로필이 존재하지 않는 경우
+     * @throws EntityNotFoundException      해당 coupleId의 커플 지출 요약 내역이 존재하지 않는 경우
+     * @throws BusinessException            COUPLE_NOT_CONNECTED
+     * @throws InfrastructureException      DB_RETRIEVE_FAILURE
      */
     CoupleBudgetSummaryResponse getBudgetSummary(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
 import ready_to_marry.userservice.common.exception.BusinessException;
+import ready_to_marry.userservice.common.exception.ForbiddenException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
 
 /**
@@ -50,4 +51,27 @@ public interface CoupleBudgetService {
      * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void createBudgetDetail(Long userId, BudgetDetailCreateRequest request);
+
+    /**
+     * 지출 내역 ID 기준으로 특정 커플이 등록한 지출 내역 삭제
+     * 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+     * 2) 해당 지출 내역 ID의 지출 내역이 존재하는지 검증
+     * 3) 해당 지출 내역이 요청한 유저의 커플에 속해있는지 검증
+     * 4) 삭제할 지출 내역의 정보 가져오기
+     * 5) 지출 내역 삭제
+     * 6) 커플 지출 요약 내역 갱신
+     * 7) 지출 요약 내역 저장
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param budgetDetailId            삭제할 지출 내역 ID
+     * @throws EntityNotFoundException  본인의 프로필이 존재하지 않는 경우
+     * @throws EntityNotFoundException  해당 budgetDetailId의 커플 지출 내역이 존재하지 않는 경우
+     * @throws EntityNotFoundException  해당 coupleId의 커플 지출 요약 내역이 존재하지 않는 경우
+     * @throws ForbiddenException       FORBIDDEN (해당 지출 내역이 요청한 유저의 커플 지출 내역이 아닌 경우)
+     * @throws BusinessException        COUPLE_NOT_CONNECTED
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_DELETE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
+     */
+    void deleteBudgetDetail(Long userId, Long budgetDetailId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
+import ready_to_marry.userservice.budget.dto.request.TotalBudgetUpdateRequest;
 import ready_to_marry.userservice.budget.entity.CoupleBudgetDetail;
 import ready_to_marry.userservice.budget.entity.CoupleBudgetSummary;
 import ready_to_marry.userservice.budget.enums.BudgetCategory;
@@ -229,6 +230,49 @@ public class CoupleBudgetServiceImpl implements CoupleBudgetService {
         }
 
         // 7) 지출 요약 내역 저장
+        try {
+            coupleBudgetSummaryRepository.save(summary);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateTotalBudget(Long userId, TotalBudgetUpdateRequest request) {
+        // 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+        UUID coupleId = userProfileService.getCoupleIdOrThrow(userId);
+
+        Long newBudget = request.getTotalBudget();
+
+        // 2) 해당 커플 ID의 커플 지출 요약 내역이 존재하고, 이미 등록한 총 예산이 존재하는지 검증
+        CoupleBudgetSummary summary;
+        try {
+            Optional<CoupleBudgetSummary> optional = coupleBudgetSummaryRepository.findByCoupleId(coupleId);
+
+            // 2-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+            if (optional.isPresent()) {
+                summary = optional.get();
+
+                // 2-1-1) 총 예산이 이미 등록된 경우
+                if (summary.getTotalBudget() != null) {
+                    summary.setTotalBudget(newBudget);
+                    summary.setRemainingBudget(newBudget - summary.getTotalSpent());
+                } else { // 2-1-2) 총 예산이 등록되지 않은 경우
+                    log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.TOTAL_BUDGET_NOT_REGISTERED.getMessage(), MaskingUtils.maskCoupleId(coupleId));
+                    throw new BusinessException(ErrorCode.TOTAL_BUDGET_NOT_REGISTERED);
+                }
+            } else { // 2-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+                log.error("Couple budget summary not found: identifierType=coupleId, identifierValue={}", MaskingUtils.maskCoupleId(coupleId));
+                throw new EntityNotFoundException("Couple budget summary not found");
+            }
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 3) 저장
         try {
             coupleBudgetSummaryRepository.save(summary);
         } catch (DataAccessException ex) {

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
@@ -280,4 +280,45 @@ public class CoupleBudgetServiceImpl implements CoupleBudgetService {
             throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
         }
     }
+
+    @Override
+    @Transactional
+    public void deleteTotalBudget(Long userId) {
+        // 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+        UUID coupleId = userProfileService.getCoupleIdOrThrow(userId);
+
+        // 2) 해당 커플 ID의 커플 지출 요약 내역이 존재하고, 이미 등록한 총 예산이 존재하는지 검증
+        CoupleBudgetSummary summary;
+        try {
+            Optional<CoupleBudgetSummary> optional = coupleBudgetSummaryRepository.findByCoupleId(coupleId);
+
+            // 2-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+            if (optional.isPresent()) {
+                summary = optional.get();
+
+                // 2-1-1) 총 예산이 이미 등록된 경우
+                if (summary.getTotalBudget() != null) {
+                    summary.setTotalBudget(null);
+                    summary.setRemainingBudget(null);
+                } else { // 2-1-2) 총 예산이 등록되지 않은 경우
+                    log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.TOTAL_BUDGET_NOT_REGISTERED.getMessage(), MaskingUtils.maskCoupleId(coupleId));
+                    throw new BusinessException(ErrorCode.TOTAL_BUDGET_NOT_REGISTERED);
+                }
+            } else { // 2-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+                log.error("Couple budget summary not found: identifierType=coupleId, identifierValue={}", MaskingUtils.maskCoupleId(coupleId));
+                throw new EntityNotFoundException("Couple budget summary not found");
+            }
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 3) 저장
+        try {
+            coupleBudgetSummaryRepository.save(summary);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
@@ -5,8 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ready_to_marry.userservice.budget.dto.request.BudgetDetailCreateRequest;
 import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
+import ready_to_marry.userservice.budget.entity.CoupleBudgetDetail;
 import ready_to_marry.userservice.budget.entity.CoupleBudgetSummary;
+import ready_to_marry.userservice.budget.enums.BudgetCategory;
+import ready_to_marry.userservice.budget.repository.CoupleBudgetDetailRepository;
 import ready_to_marry.userservice.budget.repository.CoupleBudgetSummaryRepository;
 import ready_to_marry.userservice.common.exception.BusinessException;
 import ready_to_marry.userservice.common.exception.ErrorCode;
@@ -22,6 +26,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class CoupleBudgetServiceImpl implements CoupleBudgetService {
     private final CoupleBudgetSummaryRepository coupleBudgetSummaryRepository;
+    private final CoupleBudgetDetailRepository coupleBudgetDetailRepository;
     private final UserProfileService userProfileService;
 
     @Override
@@ -66,6 +71,86 @@ public class CoupleBudgetServiceImpl implements CoupleBudgetService {
         }
 
         // 3) 저장
+        try {
+            coupleBudgetSummaryRepository.save(summary);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void createBudgetDetail(Long userId, BudgetDetailCreateRequest request) {
+        // 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+        UUID coupleId = userProfileService.getCoupleIdOrThrow(userId);
+
+        // 2) 지출 내역 생성
+        CoupleBudgetDetail detail = CoupleBudgetDetail.builder()
+                .coupleId(coupleId)
+                .category(request.getCategory())
+                .spentAmount(request.getSpentAmount())
+                .date(request.getDate())
+                .content(request.getContent())
+                .build();
+
+        // 3) 지출 내역 저장
+        try {
+            coupleBudgetDetailRepository.save(detail);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+
+        // 4) 해당 커플 ID의 커플 지출 요약 내역이 이미 존재하는지 검증
+        CoupleBudgetSummary summary;
+        try {
+            Optional<CoupleBudgetSummary> optional = coupleBudgetSummaryRepository.findByCoupleId(coupleId);
+
+            Long spent = request.getSpentAmount();
+            BudgetCategory category = request.getCategory();
+
+            // 4-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+            if (optional.isPresent()) {
+                summary = optional.get();
+
+                // 총 지출 금액 증가
+                summary.setTotalSpent(summary.getTotalSpent() + spent);
+
+                // 4-1-1) 총 예산이 이미 등록된 경우
+                if (summary.getTotalBudget() != null) {
+                    summary.setRemainingBudget(summary.getTotalBudget() - summary.getTotalSpent());
+                } else { // 4-1-2) 총 예산이 등록되지 않은 경우
+                    summary.setRemainingBudget(null);
+                }
+
+                // 카테고리별 총 지출 금액 증가
+                switch (category) {
+                    case HALL -> summary.setHallSpent(summary.getHallSpent() + spent);
+                    case SDM -> summary.setSdmSpent(summary.getSdmSpent() + spent);
+                    case CEREMONY -> summary.setCeremonySpent(summary.getCeremonySpent() + spent);
+                    case SUPPLIES -> summary.setSuppliesSpent(summary.getSuppliesSpent() + spent);
+                    case ETC -> summary.setEtcSpent(summary.getEtcSpent() + spent);
+                }
+            } else { // 4-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+                summary = CoupleBudgetSummary.builder()
+                        .coupleId(coupleId)
+                        .totalBudget(null)
+                        .totalSpent(spent)
+                        .remainingBudget(null)
+                        .hallSpent(category == BudgetCategory.HALL ? spent : 0L)
+                        .sdmSpent(category == BudgetCategory.SDM ? spent : 0L)
+                        .ceremonySpent(category == BudgetCategory.CEREMONY ? spent : 0L)
+                        .suppliesSpent(category == BudgetCategory.SUPPLIES ? spent : 0L)
+                        .etcSpent(category == BudgetCategory.ETC ? spent : 0L)
+                        .build();
+            }
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 5) 지출 요약 내역 저장
         try {
             coupleBudgetSummaryRepository.save(summary);
         } catch (DataAccessException ex) {

--- a/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/budget/service/CoupleBudgetServiceImpl.java
@@ -1,0 +1,76 @@
+package ready_to_marry.userservice.budget.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ready_to_marry.userservice.budget.dto.request.TotalBudgetCreateRequest;
+import ready_to_marry.userservice.budget.entity.CoupleBudgetSummary;
+import ready_to_marry.userservice.budget.repository.CoupleBudgetSummaryRepository;
+import ready_to_marry.userservice.common.exception.BusinessException;
+import ready_to_marry.userservice.common.exception.ErrorCode;
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.common.util.MaskingUtils;
+import ready_to_marry.userservice.profile.service.UserProfileService;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CoupleBudgetServiceImpl implements CoupleBudgetService {
+    private final CoupleBudgetSummaryRepository coupleBudgetSummaryRepository;
+    private final UserProfileService userProfileService;
+
+    @Override
+    @Transactional
+    public void createTotalBudget(Long userId, TotalBudgetCreateRequest request) {
+        // 1) 유저(userId)로부터 커플 아이디 조회 (커플 미등록 시 예외 발생)
+        UUID coupleId = userProfileService.getCoupleIdOrThrow(userId);
+
+        // 2) 해당 커플 ID의 커플 지출 요약 내역이 이미 존재하는지 검증
+        CoupleBudgetSummary summary;
+        try {
+            Optional<CoupleBudgetSummary> optional = coupleBudgetSummaryRepository.findByCoupleId(coupleId);
+
+            // 2-1) 해당 커플 ID의 커플 지출 요약 내역이 존재하는 경우
+            if (optional.isPresent()) {
+                summary = optional.get();
+
+                // 2-1-1) 총 예산이 이미 등록된 경우
+                if (summary.getTotalBudget() != null) {
+                    log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.TOTAL_BUDGET_ALREADY_EXISTS.getMessage(), MaskingUtils.maskCoupleId(coupleId));
+                    throw new BusinessException(ErrorCode.TOTAL_BUDGET_ALREADY_EXISTS);
+                } else { // 2-1-2) 총 예산이 등록되지 않은 경우
+                    summary.setTotalBudget(request.getTotalBudget());
+                    summary.setRemainingBudget(request.getTotalBudget() - summary.getTotalSpent());
+                }
+            } else { // 2-2) 해당 커플 ID의 커플 지출 요약 내역이 존재하지 않은 경우
+                summary = CoupleBudgetSummary.builder()
+                        .coupleId(coupleId)
+                        .totalBudget(request.getTotalBudget())
+                        .totalSpent(0L)
+                        .remainingBudget(request.getTotalBudget())
+                        .hallSpent(0L)
+                        .sdmSpent(0L)
+                        .ceremonySpent(0L)
+                        .suppliesSpent(0L)
+                        .etcSpent(0L)
+                        .build();
+            }
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 3) 저장
+        try {
+            coupleBudgetSummaryRepository.save(summary);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=coupleId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskCoupleId(coupleId), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/common/dto/request/PagingRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/dto/request/PagingRequest.java
@@ -1,6 +1,8 @@
 package ready_to_marry.userservice.common.dto.request;
 
 import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 리스트 조회 시 페이징 요청 정보 DTO
@@ -8,6 +10,8 @@ import jakarta.validation.constraints.Min;
  * - page : 조회할 페이지 번호 (0부터 시작)
  * - size : 한 페이지당 조회할 데이터 개수 (최소 1)
  */
+@Getter
+@Setter
 public class PagingRequest {
     // 조회할 페이지 번호 (0부터 시작)
     @Min(0)

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     ALREADY_CONNECTED_PARTNER(1104, "Target user is already connected"),
     ALREADY_RELEASED(1105, "Couple already released or not connected"),
     COUPLE_NOT_CONNECTED(1106, "User is not connected to a couple"),
+    TOTAL_BUDGET_ALREADY_EXISTS(1107, "Total budget already exists for this couple"),
 
     // 2xxx: 인프라(시스템) 오류
     DB_SAVE_FAILURE(2101, "System error occurred while saving data to the database"),

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     ALREADY_RELEASED(1105, "Couple already released or not connected"),
     COUPLE_NOT_CONNECTED(1106, "User is not connected to a couple"),
     TOTAL_BUDGET_ALREADY_EXISTS(1107, "Total budget already exists for this couple"),
+    TOTAL_BUDGET_NOT_REGISTERED(1108, "Total budget is not registered"),
 
     // 2xxx: 인프라(시스템) 오류
     DB_SAVE_FAILURE(2101, "System error occurred while saving data to the database"),


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 커플 예산 및 지출 내역 관리 기능을 추가하여, 예산 등록·수정·삭제, 지출 내역 등록·삭제, 지출 요약 내역 조회, 지출 내역 페이징 조회를 구현했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- BudgetCategory enum 정의
   - 지출 카테고리(HALL, SDM, CEREMONY, SUPPLIES, ETC)를 관리하기 위한 BudgetCategory 추가

- 엔티티 및 레포지토리 추가
  - CoupleBudgetDetail 엔티티 및 CoupleBudgetDetailRepository 추가
  - CoupleBudgetSummary 엔티티 및 CoupleBudgetSummaryRepository 추가

- ErrorCode 확장
   - TOTAL_BUDGET_ALREADY_EXISTS, TOTAL_BUDGET_NOT_REGISTERED 추

- 커플 총 예산 기능
   - 등록
      - TotalBudgetCreateRequest DTO 추가
      - CoupleBudgetService.createTotalBudget 선언 및 CoupleBudgetServiceImpl에 createTotalBudget 구현
      - CoupleBudgetController에 POST /users/me/budgets/total-budget 엔드포인트 추가
   
   - 수정
      - TotalBudgetUpdateRequest DTO 추가
      - CoupleBudgetService.updateTotalBudget 선언 및 CoupleBudgetServiceImpl에 updateTotalBudget 구현
      - CoupleBudgetController에 PATCH /users/me/budgets/total-budget 엔드포인트 추가
   
   - 삭제
      - CoupleBudgetService.deleteTotalBudget 선언 및 CoupleBudgetServiceImpl에 deleteTotalBudget 구현
      - CoupleBudgetController에 DELETE /users/me/budgets/total-budget 엔드포인트 추가

- 커플 지출 내역 기능
   - 등록
      - BudgetDetailCreateRequest DTO 추가
      - CoupleBudgetService.createBudgetDetail 선언 및 CoupleBudgetServiceImpl에 createBudgetDetail 구현
      - CoupleBudgetController에 POST /users/me/budgets/details 엔드포인트 추가

   - 삭제
      - CoupleBudgetService.deleteBudgetDetail 선언 및 CoupleBudgetServiceImpl에 deleteBudgetDetail 구현
      - CoupleBudgetController에 DELETE /users/me/budgets/details/{budgetDetailId} 엔드포인트 추가
   
   - 페이징 조회
      - CoupleBudgetDetailProjection 인터페이스 생성: 필요한 필드만 조회하기 위한 Projection 정의
      - CoupleBudgetDetailRepository에 findByCoupleIdOrderByDateDesc(UUID, Pageable) 메서드 추가
      - PagingRequest 클래스에 Lombok @Getter/@Setter 추가
      - CoupleBudgetDetailResponse DTO 추가
      - CoupleBudgetService.getBudgetDetailList 선언 및 CoupleBudgetServiceImpl에 getBudgetDetailList 구현
      - CoupleBudgetController에 GET /users/me/budgets/details 엔드포인트 추가
      - GET /users/me/budgets/details PagingRequest 파라미터에 @Valid 적용하여 PagingRequest 유효성 검증 추가

-  커플 지출 요약 내역 조회 기능
   - CoupleBudgetSummaryResponse DTO 추가
   - CoupleBudgetService.getBudgetSummary 선언 및 CoupleBudgetServiceImpl에 getBudgetSummary 구현
   - CoupleBudgetController에 GET /users/me/budgets/summary 엔드포인트 추가
   - CoupleBudgetService.getBudgetSummary 메서드 주석에 @return 설명 추가

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
