### PR TITLE
Feat/user notification: DynamoDB 기반 유저 알림 목록 조회 기능 추가 및 AWS 설정 통합

### DIFF
--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     // AWS SDK for S3
     implementation 'software.amazon.awssdk:s3:2.20.124'
 
+    // AWS SDK for Dynamodb
+    implementation 'software.amazon.awssdk:dynamodb:2.20.124'
+
     // Service Discovery (Eureka Client)
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 

--- a/UserService/src/main/java/ready_to_marry/userservice/common/config/AwsProperties.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/config/AwsProperties.java
@@ -1,4 +1,4 @@
-package ready_to_marry.userservice.profile.config;
+package ready_to_marry.userservice.common.config;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -6,15 +6,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * application.properties의 S3 설정을 바인딩
+ * application.properties의 S3, DynamoDB 설정을 바인딩
  */
 @Getter
 @Setter
 @Configuration
 @ConfigurationProperties(prefix = "cloud.aws")
-public class S3Properties {
+public class AwsProperties {
     // S3 업로드에 사용할 버킷 이름 설정
     private S3 s3;
+
+    // DynamoDB 조회할 테이블 이름 설정
+    private Dynamodb dynamodb;
 
     // AWS 액세스 키 및 시크릿 키 설정
     private Credentials credentials;
@@ -26,6 +29,12 @@ public class S3Properties {
     @Setter
     public static class S3 {
         private String bucket;
+    }
+
+    @Getter
+    @Setter
+    public static class Dynamodb {
+        private String tableName;
     }
 
     @Getter

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode {
     INVITE_CODE_DELETE_FAILURE(2106, "System error occurred while deleting invite code from redis"),
     INVITE_CODE_RETRIEVE_FAILURE(2107, "System error occurred while retrieving invite code from redis"),
     INVITE_CODE_GENERATION_FAILURE(2108, "System error occurred while generating unique invite code after multiple attempts"),
+    EXCLUSIVE_KEY_ENCODING_FAILURE(2109, "System error occurred while encoding DynamoDB ExclusiveStartKey"),
+    EXCLUSIVE_KEY_DECODING_FAILURE(2110, "System error occurred while decoding DynamoDB ExclusiveStartKey"),
 
     // 3xxx: 보안 및 인가 오류
     FORBIDDEN(3101, "You do not have permission to access this resource");

--- a/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
@@ -109,7 +109,6 @@ public final class MaskingUtils {
 
     /**
      * 커플 ID 부분 마스킹
-     *
      * 예: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d → 1a2b...5c6d
      */
     public static String maskCoupleId(UUID coupleId) {
@@ -123,5 +122,22 @@ public final class MaskingUtils {
         }
 
         return id.substring(0, 4) + "..." + id.substring(id.length() - 4);
+    }
+
+    /**
+     * ExclusiveStartKey(Base64) 문자열 부분 마스킹
+     * 예: 전체 길이가 40자라면, “앞 8자 + ... + 뒤 8자” 형태로 리턴
+     */
+    public static String maskExclusiveStartKey(String cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        int len = cursor.length();
+        if (len <= 16) {
+            return "*".repeat(len);
+        }
+        String head = cursor.substring(0, 8);
+        String tail = cursor.substring(len - 8);
+        return head + "..." + tail;
     }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/config/DynamoDbConfig.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/config/DynamoDbConfig.java
@@ -1,0 +1,34 @@
+package ready_to_marry.userservice.notification.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import ready_to_marry.userservice.common.config.AwsProperties;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+/**
+ * AWS DynamoDB에 접근하기 위한 DynamoDbClient를 생성 및 설정하는 Configuration 클래스
+ */
+@Configuration
+@RequiredArgsConstructor
+public class DynamoDbConfig {
+    private final AwsProperties awsProperties;
+
+    @Bean
+    public DynamoDbClient dynamoDbClient() {
+        return DynamoDbClient.builder()
+                .region(Region.of(awsProperties.getRegion().getStaticRegion()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        awsProperties.getCredentials().getAccessKey(),
+                                        awsProperties.getCredentials().getSecretKey()
+                                )
+                        )
+                )
+                .build();
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/controller/NotificationController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/controller/NotificationController.java
@@ -1,0 +1,45 @@
+package ready_to_marry.userservice.notification.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.common.dto.response.Meta;
+import ready_to_marry.userservice.notification.dto.request.DynamoPagingRequest;
+import ready_to_marry.userservice.notification.dto.response.NotificationHistoryResponse;
+import ready_to_marry.userservice.notification.service.NotificationHistoryService;
+
+import java.util.List;
+
+/**
+ * 유저 알림 목록 조회 컨트롤러
+ */
+@RestController
+@RequestMapping("/users/me/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationHistoryService notificationHistoryService;
+
+    /**
+     * 현재 로그인한 유저의 알림 목록 조회 (DynamoDB 커서 기반 페이징)
+     *
+     * @param userId        게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param pagingRequest DynamoDB 커서 기반 페이징 요청 정보
+     * @return 성공 시 code=0, data=유저의 알림 목록 정보
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationHistoryResponse>>> getMyNotifications(@RequestHeader("X-User-Id") String userId, @Valid @ModelAttribute DynamoPagingRequest pagingRequest) {
+        Meta meta = new Meta();
+        List<NotificationHistoryResponse> notifications = notificationHistoryService.getNotificationList(userId, pagingRequest, meta);
+
+        ApiResponse<List<NotificationHistoryResponse>> response = ApiResponse.<List<NotificationHistoryResponse>>builder()
+                .code(0)
+                .message("Notification list retrieved successfully")
+                .data(notifications)
+                .meta(meta)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/dto/request/DynamoPagingRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/dto/request/DynamoPagingRequest.java
@@ -1,0 +1,28 @@
+package ready_to_marry.userservice.notification.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DynamoDB 커서 기반 페이징 요청 정보 DTO
+ *
+ * - page : 조회할 페이지 번호 (0부터 시작)
+ * - size : 한 페이지당 조회할 데이터 개수 (최소 1)
+ * - exclusiveStartKey : DynamoDB Query 시 “이 키 이후부터” 조회하기 위한 커서
+ */
+@Getter
+@Setter
+public class DynamoPagingRequest {
+    // 조회할 페이지 번호 (0부터 시작)
+    @Min(0)
+    private int page = 0;
+
+    // 한 페이지당 조회할 데이터 개수 (최소 1)
+    @Min(1)
+    private int size = 20;
+
+    // DynamoDB 커서(ExclusiveStartKey)를 Base64/String 형태로 받은 값
+    // 첫 요청 시에는 null로 보내면 DynamoDB가 처음부터 조회
+    private String exclusiveStartKey;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/dto/response/NotificationHistoryResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/dto/response/NotificationHistoryResponse.java
@@ -1,0 +1,34 @@
+package ready_to_marry.userservice.notification.dto.response;
+
+import lombok.*;
+
+/**
+ * 알림 이력 (목록) 조회 응답 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationHistoryResponse {
+    // 알림이 생성된 일시 (ISO 8601 형식, 예: 2025-06-05T14:30:00)
+    private String createdAt;
+
+    // 알림 제목
+    private String title;
+
+    // 알림 메시지 내용
+    private String message;
+
+    // 알림과 연관된 금액 정보
+    private String amount;
+
+    // 알림과 연관된 계약 식별자
+    private String contractId;
+
+    // 알림 상태
+    private String status;
+
+    // 다음 페이지 조회 시 사용될 커서를 담아서 반환
+    private String nextExclusiveStartKey;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryDynamoRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryDynamoRepository.java
@@ -1,0 +1,136 @@
+package ready_to_marry.userservice.notification.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import ready_to_marry.userservice.common.config.AwsProperties;
+import ready_to_marry.userservice.common.exception.ErrorCode;
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.common.util.MaskingUtils;
+import ready_to_marry.userservice.notification.dto.request.DynamoPagingRequest;
+import ready_to_marry.userservice.notification.dto.response.NotificationHistoryResponse;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class NotificationHistoryDynamoRepository implements NotificationHistoryRepository {
+    private final DynamoDbClient dynamoDbClient;
+    private final AwsProperties awsProperties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public List<NotificationHistoryResponse> findByUserId(String userId, DynamoPagingRequest pagingRequest) {
+        // 1) QueryRequest 빌더 생성
+        QueryRequest.Builder queryBuilder = QueryRequest.builder()
+                .tableName(awsProperties.getDynamodb().getTableName())
+                .keyConditionExpression("id = :userId")
+                .expressionAttributeValues(Map.of(":userId", AttributeValue.fromS(userId)))
+                .scanIndexForward(false)               // 최신순 정렬
+                .limit(pagingRequest.getSize());       // 페이지 크기만큼만 조회
+
+        // 2) 클라이언트가 보낸 exclusiveStartKey(Base64 String)가 있으면 디코딩해서 ExclusiveStartKey로 설정
+        if (pagingRequest.getExclusiveStartKey() != null && !pagingRequest.getExclusiveStartKey().isBlank()) {
+            Map<String, AttributeValue> eks = decodeExclusiveStartKey(pagingRequest.getExclusiveStartKey());
+            queryBuilder.exclusiveStartKey(eks);
+        }
+
+        QueryResponse response;
+        try {
+            // 3) 실제 DynamoDB 쿼리 실행
+            response = dynamoDbClient.query(queryBuilder.build());
+        } catch (Exception ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskUserId(Long.parseLong(userId)), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 4) 조회된 아이템을 DTO로 매핑
+        List<NotificationHistoryResponse> items = response.items().stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+
+        // 5) LastEvaluatedKey를 Base64 직렬화하여 리스트 마지막 DTO에 넣어준다
+        Map<String, AttributeValue> lastEvaluatedKey = response.lastEvaluatedKey();
+        if (lastEvaluatedKey != null && !lastEvaluatedKey.isEmpty()) {
+            String nextCursor = encodeExclusiveStartKey(lastEvaluatedKey);
+            if (!items.isEmpty()) {
+                // 리스트의 마지막 아이템에만 nextExclusiveStartKey 필드를 채워서 반환
+                NotificationHistoryResponse lastDto = items.get(items.size() - 1);
+                lastDto.setNextExclusiveStartKey(nextCursor);
+            }
+        }
+
+        return items;
+    }
+
+    /**
+     * DynamoDB Item(Map<String, AttributeValue>) → NotificationHistoryResponse DTO 변환
+     */
+    private NotificationHistoryResponse mapToResponse(Map<String, AttributeValue> item) {
+        return NotificationHistoryResponse.builder()
+                .createdAt(item.get("createdAt").s())
+                .title(item.getOrDefault("title", AttributeValue.fromS("")).s())
+                .message(item.getOrDefault("message", AttributeValue.fromS("")).s())
+                .amount(item.getOrDefault("amount", AttributeValue.fromN("0")).n())
+                .contractId(item.getOrDefault("contractId", AttributeValue.fromN("0")).n())
+                .status(item.getOrDefault("status", AttributeValue.fromS("")).s())
+                .build();
+    }
+
+    /**
+     * LastEvaluatedKey(Map<String, AttributeValue>)를 JSON으로 바꾸고 Base64 인코딩
+     * → 클라이언트에게 nextExclusiveStartKey로 전달
+     */
+    private String encodeExclusiveStartKey(Map<String, AttributeValue> lastEvaluatedKey) {
+        try {
+            // AttributeValue 맵을 simpleMap(Map<String, String>)으로 바꾸자
+            Map<String, String> simpleMap = lastEvaluatedKey.entrySet().stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> {
+                                AttributeValue v = e.getValue();
+                                if (v.s() != null) return v.s();
+                                if (v.n() != null) return v.n();
+                                // (필요시 다른 타입 처리)
+                                return "";
+                            }
+                    ));
+            String json = objectMapper.writeValueAsString(simpleMap);
+            return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        } catch (JsonProcessingException ex) {
+            log.error("{}: identifierType=exclusiveStartKey, identifierValue={}", ErrorCode.EXCLUSIVE_KEY_ENCODING_FAILURE.getMessage(), MaskingUtils.maskExclusiveStartKey(lastEvaluatedKey.toString()), ex);
+            throw new InfrastructureException(ErrorCode.EXCLUSIVE_KEY_ENCODING_FAILURE, ex);
+        }
+    }
+
+    /**
+     * 클라이언트가 보낸 Base64(String) → JSON(Map<String, String>) → Map<String, AttributeValue> 역직렬화
+     */
+    private Map<String, AttributeValue> decodeExclusiveStartKey(String cursor) {
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(cursor);
+            String json = new String(decodedBytes, StandardCharsets.UTF_8);
+            Map<String, String> simpleMap = objectMapper.readValue(json, new TypeReference<>() {});
+            return simpleMap.entrySet().stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            e -> AttributeValue.fromS(e.getValue())
+                    ));
+        } catch (Exception ex) {
+            log.error("{}: identifierType=exclusiveStartKey, identifierValue={}", ErrorCode.EXCLUSIVE_KEY_DECODING_FAILURE.getMessage(), MaskingUtils.maskExclusiveStartKey(cursor), ex);
+            throw new InfrastructureException(ErrorCode.EXCLUSIVE_KEY_DECODING_FAILURE, ex);
+        }
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryRepository.java
@@ -1,0 +1,21 @@
+package ready_to_marry.userservice.notification.repository;
+
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.notification.dto.request.DynamoPagingRequest;
+import ready_to_marry.userservice.notification.dto.response.NotificationHistoryResponse;
+
+import java.util.List;
+
+public interface NotificationHistoryRepository {
+    /**
+     * 유저 ID 기준으로 알림 목록 조회 (DynamoDB 커서 기반 페이징)
+     *
+     * @param userId        유저 도메인 ID
+     * @param pagingRequest DynamoDB 커서 기반 페이징 요청 정보
+     * @return 알림 목록 응답
+     * @throws InfrastructureException EXCLUSIVE_KEY_ENCODING_FAILURE
+     * @throws InfrastructureException EXCLUSIVE_KEY_DECODING_FAILURE
+     * @throws InfrastructureException DB_RETRIEVE_FAILURE
+     */
+    List<NotificationHistoryResponse> findByUserId(String userId, DynamoPagingRequest pagingRequest);
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/service/NotificationHistoryService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/service/NotificationHistoryService.java
@@ -1,0 +1,26 @@
+package ready_to_marry.userservice.notification.service;
+
+import ready_to_marry.userservice.common.dto.response.Meta;
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.notification.dto.request.DynamoPagingRequest;
+import ready_to_marry.userservice.notification.dto.response.NotificationHistoryResponse;
+
+import java.util.List;
+
+/**
+ * 유저 알림 도메인의 비즈니스 로직을 제공하는 서비스 인터페이스
+ */
+public interface NotificationHistoryService {
+    /**
+     * 특정 유저의 알림 목록을 DynamoDB 커서 기반 페이징으로 조회
+     *
+     * @param userId                                유저 도메인 ID
+     * @param pagingRequest                         DynamoDB 커서 기반 페이징 요청 정보
+     * @param metaOut                               조회 메타 정보
+     * @return List<NotificationHistoryResponse>    알림 목록 (마지막 DTO에 nextExclusiveStartKey가 들어 있음)
+     * @throws InfrastructureException              EXCLUSIVE_KEY_ENCODING_FAILURE
+     * @throws InfrastructureException              EXCLUSIVE_KEY_DECODING_FAILURE
+     * @throws InfrastructureException              DB_RETRIEVE_FAILURE
+     */
+    List<NotificationHistoryResponse> getNotificationList(String userId, DynamoPagingRequest pagingRequest, Meta metaOut);
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/notification/service/NotificationHistoryServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/service/NotificationHistoryServiceImpl.java
@@ -1,0 +1,32 @@
+package ready_to_marry.userservice.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ready_to_marry.userservice.common.dto.response.Meta;
+import ready_to_marry.userservice.notification.dto.request.DynamoPagingRequest;
+import ready_to_marry.userservice.notification.dto.response.NotificationHistoryResponse;
+import ready_to_marry.userservice.notification.repository.NotificationHistoryRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationHistoryServiceImpl implements NotificationHistoryService {
+    private final NotificationHistoryRepository notificationHistoryRepository;
+
+    @Override
+    public List<NotificationHistoryResponse> getNotificationList(String userId, DynamoPagingRequest pagingRequest, Meta metaOut) {
+        // 1) 리포지토리에서 DynamoDB Query(커서 기반) 수행
+        List<NotificationHistoryResponse> result = notificationHistoryRepository.findByUserId(userId, pagingRequest);
+
+        // 2) 메타 정보 세팅
+        metaOut.setPage(pagingRequest.getPage());
+        metaOut.setSize(pagingRequest.getSize());
+
+        // 3) DynamoDB는 totalElements/totalPages를 바로 알 수 없으므로, 필요 시 별도 통계 테이블을 만들거나 생략
+        metaOut.setTotalElements(0);
+        metaOut.setTotalPages(0);
+
+        return result;
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/util/S3Storage.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/util/S3Storage.java
@@ -4,7 +4,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-import ready_to_marry.userservice.profile.config.S3Properties;
+import ready_to_marry.userservice.common.config.AwsProperties;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -25,18 +25,18 @@ import java.util.UUID;
 @Component
 @RequiredArgsConstructor
 public class S3Storage {
-    private final S3Properties s3Properties;
+    private final AwsProperties awsProperties;
     private S3Client s3Client;
 
     @PostConstruct
     public void init() {
          this.s3Client = S3Client.builder()
-                .region(Region.of(s3Properties.getRegion().getStaticRegion()))
+                .region(Region.of(awsProperties.getRegion().getStaticRegion()))
                 .credentialsProvider(
                         StaticCredentialsProvider.create(
                                 AwsBasicCredentials.create(
-                                        s3Properties.getCredentials().getAccessKey(),
-                                        s3Properties.getCredentials().getSecretKey()
+                                        awsProperties.getCredentials().getAccessKey(),
+                                        awsProperties.getCredentials().getSecretKey()
                                 )
                         )
                 )
@@ -57,7 +57,7 @@ public class S3Storage {
                 LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")) + extension;
 
         PutObjectRequest request = PutObjectRequest.builder()
-                .bucket(s3Properties.getS3().getBucket())
+                .bucket(awsProperties.getS3().getBucket())
                 .key(fileName)
                 .contentType(multipartFile.getContentType())
                 .acl(ObjectCannedACL.PUBLIC_READ)
@@ -79,7 +79,7 @@ public class S3Storage {
     public void delete(String fileUrl) {
         String key = extractKeyFromUrl(fileUrl);
         DeleteObjectRequest request = DeleteObjectRequest.builder()
-                .bucket(s3Properties.getS3().getBucket())
+                .bucket(awsProperties.getS3().getBucket())
                 .key(key)
                 .build();
 
@@ -88,8 +88,8 @@ public class S3Storage {
 
     private String getFileUrl(String key) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s",
-                s3Properties.getS3().getBucket(),
-                s3Properties.getRegion().getStaticRegion(),
+                awsProperties.getS3().getBucket(),
+                awsProperties.getRegion().getStaticRegion(),
                 key
         );
     }


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- DynamoDB를 활용한 유저 알림 목록 조회 기능을 추가하고, AWS 설정을 통합 및 리팩토링하여 S3/DynamoDB 관련 설정과 유틸 클래스를 개선했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- AWS 설정 통합 및 S3Storage 리팩토링
   - S3Properties와 DynamoDB 설정을 AwsProperties 하나로 합쳐서 관리
   - S3Storage에서 AwsProperties를 주입받도록 변경

- build.gradle에 AWS SDK for DynamoDB 의존성 추가
   - implementation 'software.amazon.awssdk:dynamodb:2.20.124' 추가

- AWS DynamoDB 접근 설정 (DynamoDbConfig)
   - AwsProperties에서 리전, 액세스 키/시크릿을 주입받아 DynamoDbClient 빈을 생성
   - DynamoDB 사용을 위한 기본 설정 완료

- ExclusiveStartKey 마스킹 유틸 및 ErrorCode
   - MaskingUtils에 maskExclusiveStartKey 메서드 추가
   - ErrorCode에 EXCLUSIVE_KEY_ENCODING_FAILURE, EXCLUSIVE_KEY_DECODING_FAILURE 추가

- DynamoPagingRequest DTO 추가 (커서 기반 페이징)
   - 페이지 번호(page), 페이지 크기(size), 커서(exclusiveStartKey)를 담는 DTO 생성 

- NotificationHistoryResponse DTO 정의
   - 알림 목록 조회 응답에 필요한 필드와 다음 페이지 커서 포함

- 사용자 알림 목록 조회 기능 구현
   - NotificationHistoryRepository 인터페이스 정의 및 NotificationHistoryDynamoRepository 구현
      - DynamoDB 쿼리, ExclusiveStartKey 인코딩/디코딩 로직 포함 
   - NotificationHistoryService.getNotificationList 선언 및 NotificationHistoryServiceImpl에서 getNotificationList 구현
   - NotificationController에 GET /users/me/notifications 엔드포인트 구현 

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
