### PR TITLE
Feat/user fcm: 유저 FCM 토큰 관리 기능 추가 

### DIFF
--- a/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/util/MaskingUtils.java
@@ -132,12 +132,35 @@ public final class MaskingUtils {
         if (cursor == null) {
             return null;
         }
+
         int len = cursor.length();
+
         if (len <= 16) {
             return "*".repeat(len);
         }
+
         String head = cursor.substring(0, 8);
         String tail = cursor.substring(len - 8);
+        return head + "..." + tail;
+    }
+
+    /**
+     * FCM 토큰 부분 마스킹
+     * 예: abcd1234xyz → *********** / abcdefghijklmnopq → abcdefgh...jklmnopq
+     */
+    public static String maskFcmToken(String token) {
+        if (token == null) {
+            return null;
+        }
+
+        int len = token.length();
+
+        if (len <= 16) {
+            return "*".repeat(len);
+        }
+
+        String head = token.substring(0, 8);
+        String tail = token.substring(len - 8);
         return head + "..." + tail;
     }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/controller/FcmTokenController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/controller/FcmTokenController.java
@@ -1,0 +1,39 @@
+package ready_to_marry.userservice.fcm.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.fcm.dto.request.FcmTokenCreateOrUpdateRequest;
+import ready_to_marry.userservice.fcm.service.FcmTokenService;
+
+/**
+ * 유저의 FCM 토큰 관련 기능을 처리하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/users/me/fcm-token")
+@RequiredArgsConstructor
+public class FcmTokenController {
+    private final FcmTokenService fcmTokenService;
+
+    /**
+     * 유저 FCM 토큰 등록/업데이트
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @param request FCM 토큰 등록/업데이트 요청 정보
+     * @return 성공 시 code=0, data=null
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> saveOrUpdateFcmToken(@RequestHeader("X-User-Id") Long userId, @Valid @RequestBody FcmTokenCreateOrUpdateRequest request) {
+        fcmTokenService.saveOrUpdateToken(userId, request);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("FCM token created/updated successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/controller/FcmTokenController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/controller/FcmTokenController.java
@@ -36,4 +36,23 @@ public class FcmTokenController {
 
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * 유저 FCM 토큰 삭제
+     *
+     * @param userId  게이트웨이가 파싱한 유저 도메인 ID (JWT에서 X-User-Id로 전달됨)
+     * @return 성공 시 code=0, data=null
+     */
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> deleteFcmToken(@RequestHeader("X-User-Id") Long userId) {
+        fcmTokenService.deleteToken(userId);
+
+        ApiResponse<Void> response = ApiResponse.<Void>builder()
+                .code(0)
+                .message("FCM token deleted successfully")
+                .data(null)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/controller/FcmTokenInternalController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/controller/FcmTokenInternalController.java
@@ -1,0 +1,33 @@
+package ready_to_marry.userservice.fcm.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ready_to_marry.userservice.common.dto.response.ApiResponse;
+import ready_to_marry.userservice.fcm.service.FcmTokenService;
+
+/**
+ * INTERNAL API 컨트롤러 - 유저 FCM 토큰 조회용
+ */
+@RestController
+@RequestMapping("/internal/user-fcm-tokens")
+@RequiredArgsConstructor
+public class FcmTokenInternalController {
+    private final FcmTokenService fcmTokenService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<String>> getFcmToken(@RequestHeader("X-User-Id") Long userId) {
+        String token = fcmTokenService.getInternalFcmToken(userId);
+
+        ApiResponse<String> response = ApiResponse.<String>builder()
+                .code(0)
+                .message("FCM token retrieved successfully")
+                .data(token)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/dto/request/FcmTokenCreateOrUpdateRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/dto/request/FcmTokenCreateOrUpdateRequest.java
@@ -1,0 +1,18 @@
+package ready_to_marry.userservice.fcm.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 유저의 FCM 토큰 등록/업데이트 요청 DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FcmTokenCreateOrUpdateRequest {
+    // FCM 토큰 문자열
+    @NotBlank
+    private String token;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/entity/FcmToken.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/entity/FcmToken.java
@@ -1,0 +1,42 @@
+package ready_to_marry.userservice.fcm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.OffsetDateTime;
+
+/**
+ * user_db.fcm_token 테이블 매핑 엔티티
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "fcm_token")
+public class FcmToken {
+    // user_id 는 user_profile 테이블의 PK(user_id)와 매핑 (One-to-One 관계)
+    @Id
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    // FCM 토큰 문자열
+    @Column(name = "fcm_token", length = 255, nullable = false)
+    private String token;
+
+    // 최초 저장 시각 (자동으로 채워짐)
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    // 마지막 갱신 시각 (자동으로 갱신)
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/repository/FcmTokenRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/repository/FcmTokenRepository.java
@@ -1,0 +1,13 @@
+package ready_to_marry.userservice.fcm.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import ready_to_marry.userservice.fcm.entity.FcmToken;
+
+/**
+ * FcmToken CRUD 및 조회용 레포지토리
+ */
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
@@ -1,0 +1,25 @@
+package ready_to_marry.userservice.fcm.service;
+
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.fcm.dto.request.FcmTokenCreateOrUpdateRequest;
+
+/**
+ * 유저 FCM 토큰 도메인의 비즈니스 로직을 제공하는 서비스 인터페이스
+ */
+public interface FcmTokenService {
+    /**
+     * 현재 로그인한 유저의 FCM 토큰을 등록하거나, 이미 존재하면 업데이트
+     * 1) userId로 기존 FcmToken을 조회하거나 새 엔티티를 준비
+     * 1-1) 해당 userId의 토큰이 존재하는 경우
+     * 1-1-1) DB에 저장된 토큰과 요청으로 들어온 토큰이 다른 경우 → 업데이트
+     * 1-1-2) DB에 저장된 토큰과 요청 토큰이 동일한 경우
+     * 1-2) 해당 userId의 토큰이 존재하지 않는 경우 → 새로운 엔티티 생성
+     * 2) 저장 혹은 업데이트
+     *
+     * @param userId            X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request           유저의 FCM 토큰 등록/업데이트 요청 DTO
+     * @throws InfrastructureException DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException DB_SAVE_FAILURE
+     */
+    void saveOrUpdateToken(Long userId, FcmTokenCreateOrUpdateRequest request);
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
@@ -16,10 +16,10 @@ public interface FcmTokenService {
      * 1-2) 해당 userId의 토큰이 존재하지 않는 경우 → 새로운 엔티티 생성
      * 2) 저장 혹은 업데이트
      *
-     * @param userId            X-User-Id 헤더에서 전달받은 유저 도메인 ID
-     * @param request           유저의 FCM 토큰 등록/업데이트 요청 DTO
-     * @throws InfrastructureException DB_RETRIEVE_FAILURE
-     * @throws InfrastructureException DB_SAVE_FAILURE
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @param request                   유저의 FCM 토큰 등록/업데이트 요청 DTO
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void saveOrUpdateToken(Long userId, FcmTokenCreateOrUpdateRequest request);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
@@ -1,5 +1,6 @@
 package ready_to_marry.userservice.fcm.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import ready_to_marry.userservice.common.exception.InfrastructureException;
 import ready_to_marry.userservice.fcm.dto.request.FcmTokenCreateOrUpdateRequest;
 
@@ -22,4 +23,16 @@ public interface FcmTokenService {
      * @throws InfrastructureException  DB_SAVE_FAILURE
      */
     void saveOrUpdateToken(Long userId, FcmTokenCreateOrUpdateRequest request);
+
+    /**
+     * 현재 로그인한 유저의 FCM 토큰을 삭제
+     * 1) userId로 기존 FcmToken을 조회
+     * 2) 삭제
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @throws EntityNotFoundException  본인의 등록된 FCM 토큰 정보가 존재하지 않는 경우
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     * @throws InfrastructureException  DB_DELETE_FAILURE
+     */
+    void deleteToken(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
@@ -35,4 +35,16 @@ public interface FcmTokenService {
      * @throws InfrastructureException  DB_DELETE_FAILURE
      */
     void deleteToken(Long userId);
+
+    /**
+     * Internal API로 전달받은 userId로 해당 유저의 FCM 토큰을 조회
+     * 1) userId로 FcmToken 엔티티를 조회
+     * 2) 조회된 토큰(String) 반환
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @return String                   조회된 FCM 토큰 문자열
+     * @throws EntityNotFoundException  본인의 등록된 FCM 토큰 정보가 존재하지 않는 경우
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     */
+    String getInternalFcmToken(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
@@ -1,0 +1,62 @@
+package ready_to_marry.userservice.fcm.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ready_to_marry.userservice.common.exception.ErrorCode;
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.common.util.MaskingUtils;
+import ready_to_marry.userservice.fcm.dto.request.FcmTokenCreateOrUpdateRequest;
+import ready_to_marry.userservice.fcm.entity.FcmToken;
+import ready_to_marry.userservice.fcm.repository.FcmTokenRepository;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmTokenServiceImpl implements FcmTokenService {
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Override
+    @Transactional
+    public void saveOrUpdateToken(Long userId, FcmTokenCreateOrUpdateRequest request) {
+        // 1) userId로 기존 FcmToken을 조회하거나 새 엔티티를 준비
+        FcmToken fcmToken;
+        try {
+            Optional<FcmToken> optional = fcmTokenRepository.findById(userId);
+
+            String token = request.getToken();
+
+            // 1-1) 해당 userId의 토큰이 존재하는 경우
+            if (optional.isPresent()) {
+                fcmToken = optional.get();
+
+                // 1-1-1) DB에 저장된 토큰과 요청으로 들어온 토큰이 다른 경우 → 업데이트
+                if (!fcmToken.getToken().equals(token)) {
+                    fcmToken.setToken(token);
+                } else { // 1-1-2) DB에 저장된 토큰과 요청 토큰이 동일한 경우
+                    return;
+                }
+            } else { // 1-2) 해당 userId의 토큰이 존재하지 않는 경우 → 새로운 엔티티 생성
+                fcmToken = FcmToken.builder()
+                        .userId(userId)
+                        .token(token)
+                        .build();
+            }
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+
+        // 2) 저장 혹은 업데이트
+        try {
+            fcmTokenRepository.save(fcmToken);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_SAVE_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+            throw new InfrastructureException(ErrorCode.DB_SAVE_FAILURE, ex);
+        }
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
@@ -85,4 +85,22 @@ public class FcmTokenServiceImpl implements FcmTokenService {
             throw new InfrastructureException(ErrorCode.DB_DELETE_FAILURE, ex);
         }
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String getInternalFcmToken(Long userId) {
+        // 1) userId로 FcmToken 엔티티를 조회
+        try {
+            return fcmTokenRepository.findById(userId)
+                    // 2) 조회된 토큰(String) 반환
+                    .map(FcmToken::getToken)
+                    .orElseThrow(() -> {
+                        log.error("Fcm token not found: identifierType=userId, identifierValue={}", MaskingUtils.maskUserId(userId));
+                        return new EntityNotFoundException("Fcm token not found");
+                    });
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+    }
 }


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 유저 FCM 토큰을 등록, 업데이트, 삭제 및 조회할 수 있는 기능을 추가했습니다.
- 내부 API를 통해 서비스 간 통신 시 특정 유저의 FCM 토큰을 가져올 수 있도록 구현했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- FCM 토큰 엔티티 및 리포지토리
   - FcmToken 엔티티 추가  
   - FcmTokenRepository 인터페이스 추가  

- 마스킹 유틸
   - MaskingUtils.maskFcmToken 메서드 추가  

- FCM 토큰 등록/업데이트
   - FcmTokenCreateOrUpdateRequest DTO 추가   
   - FcmTokenService.saveOrUpdateToken 메서드 선언 및 FcmTokenServiceImpl에 saveOrUpdateToken 구현 
   - FcmTokenController에 POST /users/me/fcm-token 엔드포인트 추가 

- FCM 토큰 삭제
   - FcmTokenService.deleteToken 메서드 선언 및 FcmTokenServiceImpl에 deleteToken 구현 
   - FcmTokenController에 DELETE /users/me/fcm-token 엔드포인트 추가 

- Internal API: FCM 토큰 조회
   - FcmTokenService.getInternalFcmToken 메서드 선언 및 FcmTokenServiceImpl에 getInternalFcmToken 구현
   -  FcmTokenInternalController에 GET /internal/user-fcm-tokens 엔드포인트 추가

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
