### PR TITLE
Feat/profile push notification flag: 유저 프로필 조회 응답에 푸시 알림 허용 여부 추가

### DIFF
--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
@@ -47,4 +47,14 @@ public interface FcmTokenService {
      * @throws InfrastructureException  DB_RETRIEVE_FAILURE
      */
     String getInternalFcmToken(Long userId);
+
+    /**
+     * 현재 로그인한 유저의 FCM 토큰이 저장되어 있는지 확인
+     * 1) userId로 저장된 FcmToken이 존재하는지 확인
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @return boolean                  토큰이 있으면 true, 없으면 false
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     */
+    boolean existsByUserId(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
@@ -103,4 +103,16 @@ public class FcmTokenServiceImpl implements FcmTokenService {
             throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
         }
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByUserId(Long userId) {
+        // 1) userId로 저장된 FcmToken이 존재하는지 확인
+        try {
+            return fcmTokenRepository.existsById(userId);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/UserProfileResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/UserProfileResponse.java
@@ -3,7 +3,7 @@ package ready_to_marry.userservice.profile.dto.response;
 import lombok.*;
 
 /**
- * 로그인한 유저의 프로필 조회 결과 응답 DTO
+ * 로그인한 유저의 프로필 조회 결과 + 유저 푸시 알림 허용 여부 응답 DTO
  */
 @Getter
 @Setter
@@ -22,4 +22,7 @@ public class UserProfileResponse {
 
     // 커플 연결 여부
     private boolean connectedCouple;
+
+    // 유저 푸시 알림 허용 여부
+    private boolean pushNotificationEnabled;
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -33,10 +33,11 @@ public interface UserProfileService {
     /**
      * 로그인한 유저의 프로필 정보 조회
      * 1) 유저 프로필 조회
-     * 2) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부를 포함한 응답 DTO 반환
+     * 2) FCM 토큰 존재 여부로 푸시 허용 여부 판단
+     * 3) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부, 유저 푸시 알림 허용 여부를 포함한 응답 DTO 반환
      *
      * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
-     * @return UserProfileResponse          프로필 조회 결과 응답 DTO (유저 프로필 정보 및 커플 연결 여부 포함)
+     * @return UserProfileResponse          프로필 조회 결과 응답 DTO (유저 프로필 정보 및 커플 연결 여부 및 유저 푸시 알림 허용 여부 포함)
      * @throws EntityNotFoundException      유저 프로필이 존재하지 않는 경우
      * @throws InfrastructureException      DB_RETRIEVE_FAILURE
      */

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
@@ -84,12 +84,16 @@ public class UserProfileServiceImpl implements UserProfileService {
             throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
         }
 
-        // 2) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부를 포함한 응답 DTO 반환
+        // 2) FCM 토큰 존재 여부로 푸시 허용 여부 판단
+        boolean pushEnabled = fcmTokenService.existsByUserId(userId);
+
+        // 3) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부, 유저 푸시 알림 허용 여부를 포함한 응답 DTO 반환
         return UserProfileResponse.builder()
                 .name(profile.getName())
                 .phone(profile.getPhone())
                 .profileImgUrl(profile.getProfileImgUrl())
                 .connectedCouple(profile.getCoupleId() != null)
+                .pushNotificationEnabled(pushEnabled)
                 .build();
     }
 


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 유저 프로필 조회 시 “푸시 알림 허용 여부” 정보를 함께 제공하도록 기능을 확장했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- FCM 토큰 존재 여부 확인 메서드 추가
   - FcmTokenService, FcmTokenServiceImpl에서 existsByUserId 선언 및 구현 

- 프로필 조회 응답 DTO 확장
   - UserProfileResponse 에 pushNotificationEnabled 필드 추가
   - UserProfileService.getMyProfile 주석 및 반환 설명 업데이트
   - UserProfileServiceImpl.getMyProfile 에서 FcmTokenService.existsByUserId 호출해 pushNotificationEnabled 값 설정
   
## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
