### PR TITLE
Feat/profile push notification flag: 유저 프로필 조회 응답에 푸시 알림 허용 여부 추가 및 쿠폰 발급 기능 추가

### DIFF
--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly     'org.junit.platform:junit-platform-launcher'
+
+    // kafka 의존성
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/common/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     INVITE_CODE_GENERATION_FAILURE(2108, "System error occurred while generating unique invite code after multiple attempts"),
     EXCLUSIVE_KEY_ENCODING_FAILURE(2109, "System error occurred while encoding DynamoDB ExclusiveStartKey"),
     EXCLUSIVE_KEY_DECODING_FAILURE(2110, "System error occurred while decoding DynamoDB ExclusiveStartKey"),
+    KAFKA_SERIALIZATION_ERROR(2601, "Failed to serialization message to Kafka"),
+    KAFKA_CONNECTION_ERROR(2602, "Failed to connect to Kafka broker"),
+    UNKNOWN_ERROR(2603, "Unknown error"),
 
     // 3xxx: 보안 및 인가 오류
     FORBIDDEN(3101, "You do not have permission to access this resource");

--- a/UserService/src/main/java/ready_to_marry/userservice/coupon/CouponController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/coupon/CouponController.java
@@ -1,0 +1,22 @@
+package ready_to_marry.userservice.coupon;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ready_to_marry.userservice.coupon.dto.CouponRequest;
+import ready_to_marry.userservice.coupon.service.CouponKafkaProducer;
+
+@RestController
+@RequestMapping("/coupons")
+@RequiredArgsConstructor
+public class CouponController {
+    private final CouponKafkaProducer couponKafkaProducer;
+
+    @PostMapping
+    public String registerCoupon(@RequestBody CouponRequest couponRequest) {
+        couponKafkaProducer.sendCoupon(couponRequest);
+        return "Kafka Coupon 전송 완료";
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/coupon/controller/CouponController.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/coupon/controller/CouponController.java
@@ -1,4 +1,4 @@
-package ready_to_marry.userservice.coupon;
+package ready_to_marry.userservice.coupon.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/UserService/src/main/java/ready_to_marry/userservice/coupon/dto/CouponRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/coupon/dto/CouponRequest.java
@@ -1,0 +1,15 @@
+package ready_to_marry.userservice.coupon.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CouponRequest {
+    private Long userId;
+    private String couponCode;
+    private String couponName;
+    private String couponContent;
+    private Long couponPrice;
+    private LocalDateTime issuedAt;
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/coupon/dto/CouponRequest.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/coupon/dto/CouponRequest.java
@@ -7,9 +7,5 @@ import java.time.LocalDateTime;
 @Data
 public class CouponRequest {
     private Long userId;
-    private String couponCode;
-    private String couponName;
-    private String couponContent;
-    private Long couponPrice;
-    private LocalDateTime issuedAt;
+    private String couponId;
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/coupon/service/CouponKafkaProducer.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/coupon/service/CouponKafkaProducer.java
@@ -1,0 +1,34 @@
+package ready_to_marry.userservice.coupon.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.errors.NetworkException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import ready_to_marry.userservice.common.exception.ErrorCode;
+import ready_to_marry.userservice.common.exception.InfrastructureException;
+import ready_to_marry.userservice.coupon.dto.CouponRequest;
+
+@RequiredArgsConstructor
+@Service
+public class CouponKafkaProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private static final String TOPIC = "coupon";
+
+    public void sendCoupon(CouponRequest dto) {
+        try {
+            String json = objectMapper.writeValueAsString(dto);
+            kafkaTemplate.send(TOPIC, json);
+        } catch (JsonProcessingException e) {
+            throw new InfrastructureException(ErrorCode.KAFKA_SERIALIZATION_ERROR, e);
+        } catch (KafkaException | TimeoutException | NetworkException e) {
+            throw new InfrastructureException(ErrorCode.KAFKA_CONNECTION_ERROR, e);
+        } catch (Exception e) {
+            throw new InfrastructureException(ErrorCode.UNKNOWN_ERROR, e);
+        }
+    }
+}

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenService.java
@@ -47,4 +47,14 @@ public interface FcmTokenService {
      * @throws InfrastructureException  DB_RETRIEVE_FAILURE
      */
     String getInternalFcmToken(Long userId);
+
+    /**
+     * 현재 로그인한 유저의 FCM 토큰이 저장되어 있는지 확인
+     * 1) userId로 저장된 FcmToken이 존재하는지 확인
+     *
+     * @param userId                    X-User-Id 헤더에서 전달받은 유저 도메인 ID
+     * @return boolean                  토큰이 있으면 true, 없으면 false
+     * @throws InfrastructureException  DB_RETRIEVE_FAILURE
+     */
+    boolean existsByUserId(Long userId);
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/fcm/service/FcmTokenServiceImpl.java
@@ -103,4 +103,16 @@ public class FcmTokenServiceImpl implements FcmTokenService {
             throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
         }
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByUserId(Long userId) {
+        // 1) userId로 저장된 FcmToken이 존재하는지 확인
+        try {
+            return fcmTokenRepository.existsById(userId);
+        } catch (DataAccessException ex) {
+            log.error("{}: identifierType=userId, identifierValue={}", ErrorCode.DB_RETRIEVE_FAILURE.getMessage(), MaskingUtils.maskUserId(userId), ex);
+            throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
+        }
+    }
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/UserProfileResponse.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/dto/response/UserProfileResponse.java
@@ -3,7 +3,7 @@ package ready_to_marry.userservice.profile.dto.response;
 import lombok.*;
 
 /**
- * 로그인한 유저의 프로필 조회 결과 응답 DTO
+ * 로그인한 유저의 프로필 조회 결과 + 유저 푸시 알림 허용 여부 응답 DTO
  */
 @Getter
 @Setter
@@ -22,4 +22,7 @@ public class UserProfileResponse {
 
     // 커플 연결 여부
     private boolean connectedCouple;
+
+    // 유저 푸시 알림 허용 여부
+    private boolean pushNotificationEnabled;
 }

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileService.java
@@ -33,10 +33,11 @@ public interface UserProfileService {
     /**
      * 로그인한 유저의 프로필 정보 조회
      * 1) 유저 프로필 조회
-     * 2) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부를 포함한 응답 DTO 반환
+     * 2) FCM 토큰 존재 여부로 푸시 허용 여부 판단
+     * 3) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부, 유저 푸시 알림 허용 여부를 포함한 응답 DTO 반환
      *
      * @param userId                        X-User-Id 헤더에서 전달받은 유저 도메인 ID
-     * @return UserProfileResponse          프로필 조회 결과 응답 DTO (유저 프로필 정보 및 커플 연결 여부 포함)
+     * @return UserProfileResponse          프로필 조회 결과 응답 DTO (유저 프로필 정보 및 커플 연결 여부 및 유저 푸시 알림 허용 여부 포함)
      * @throws EntityNotFoundException      유저 프로필이 존재하지 않는 경우
      * @throws InfrastructureException      DB_RETRIEVE_FAILURE
      */

--- a/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/profile/service/UserProfileServiceImpl.java
@@ -84,12 +84,16 @@ public class UserProfileServiceImpl implements UserProfileService {
             throw new InfrastructureException(ErrorCode.DB_RETRIEVE_FAILURE, ex);
         }
 
-        // 2) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부를 포함한 응답 DTO 반환
+        // 2) FCM 토큰 존재 여부로 푸시 허용 여부 판단
+        boolean pushEnabled = fcmTokenService.existsByUserId(userId);
+
+        // 3) 실명(표시명), 연락처, 프로필 사진 저장 주소, 커플 연결 여부, 유저 푸시 알림 허용 여부를 포함한 응답 DTO 반환
         return UserProfileResponse.builder()
                 .name(profile.getName())
                 .phone(profile.getPhone())
                 .profileImgUrl(profile.getProfileImgUrl())
                 .connectedCouple(profile.getCoupleId() != null)
+                .pushNotificationEnabled(pushEnabled)
                 .build();
     }
 

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -42,3 +42,8 @@ app.url-base=${APP_URL_BASE}
 
 # Invite Code
 invite-code.ttl=${INVITE_CODE_TTL:10m}
+
+spring.kafka.bootstrap-servers=${SPRING_KAFKA_BOOTSTRAP_SERVERS}
+spring.kafka.consumer.group-id=group
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- coupon 발급 요청 api 구현 및 Kafka 의존성 추가
- 유저 프로필 조회 시 “푸시 알림 허용 여부” 정보를 함께 제공하도록 기능을 확장했습니다.

## ✅ 작업 내용 (Changes)
- [X] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- 쿠폰 발급 요청 시 kafka에 couponId, userId 전송

- FCM 토큰 존재 여부 확인 메서드 추가
   - FcmTokenService, FcmTokenServiceImpl에서 existsByUserId 선언 및 구현 

- 프로필 조회 응답 DTO 확장
   - UserProfileResponse 에 pushNotificationEnabled 필드 추가
   - UserProfileService.getMyProfile 주석 및 반환 설명 업데이트
   - UserProfileServiceImpl.getMyProfile 에서 FcmTokenService.existsByUserId 호출해 pushNotificationEnabled 값 설정

## 📸 스크린샷 (Optional)
X

## 🔗 관련 이슈 (Linked Issue)
X

## 📌 참고 사항 (Additional Notes)
X