### PR TITLE
Feat/expose actuator and enable prometheus: Micrometer Prometheus 레지스트리 및 actuator 설정 활성화

### DIFF
--- a/UserService/build.gradle
+++ b/UserService/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Micrometer-Registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     // Retry & AOP
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -20,8 +20,11 @@ spring.data.redis.sentinel.nodes=${SPRING_DATA_REDIS_SENTINEL_NODES}
 spring.data.redis.sentinel.password=${SPRING_DATA_REDIS_SENTINEL_PASSWORD}
 spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD}
 
-# /actuator/health
-management.endpoints.web.exposure.include=health
+# /actuator
+management.endpoints.web.exposure.include=*
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.base-path=/actuator
+management.prometheus.metrics.export.enabled=true
 
 # Eureka
 spring.application.name=user-service


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Micrometer-Prometheus 레지스트리 의존성을 추가하고, Actuator 엔드포인트를 전체 노출하며 Prometheus 메트릭 수집을 활성화했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- build.gradle에 micrometer-registry-prometheus 의존성 추가
- management.endpoints.web.exposure.include 값을 health → *로 변경하여 모든 Actuator 엔드포인트 노출
- management.endpoint.prometheus.enabled=true 설정으로 Prometheus 스크랩 엔드포인트 활성화
- management.endpoints.web.base-path=/actuator로 Actuator 기본 경로 지정
- management.prometheus.metrics.export.enabled=true로 Micrometer Prometheus 레지스트리 메트릭 내보내기 활성화

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
