### PR TITLE
Fix/notification dynamo userid prefix: DynamoDB 조회 시 userId에 'user' 접두사 추가

### DIFF
--- a/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryDynamoRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryDynamoRepository.java
@@ -34,6 +34,7 @@ public class NotificationHistoryDynamoRepository implements NotificationHistoryR
     @Override
     public List<NotificationHistoryResponse> findByUserId(String userId, DynamoPagingRequest pagingRequest) {
         // 1) QueryRequest 빌더 생성
+        userId = "user" + userId;
         QueryRequest.Builder queryBuilder = QueryRequest.builder()
                 .tableName(awsProperties.getDynamodb().getTableName())
                 .keyConditionExpression("id = :userId")


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- DynamoDB 파티션 키 형식에 맞춰, 조회 시 userId 앞에 "user" 접두사를 자동 추가하도록 수정했습니다.

## ✅ 작업 내용 (Changes)
- [ ] 기능 추가 / 수정
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- NotificationHistoryDynamoRepository.findByUserId 메서드에서 userId = "user" + userId; 형태로 변환하여 DynamoDB 조회 시 올바른 파티션 키(예: user1, user234)를 사용하도록 변경

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
