### PR TITLE
Feat/limit actuator exposure: Actuator 노출 엔드포인트 최소화 설정

### DIFF
--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -21,7 +21,7 @@ spring.data.redis.sentinel.password=${SPRING_DATA_REDIS_SENTINEL_PASSWORD}
 spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD}
 
 # /actuator
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.base-path=/actuator
 management.prometheus.metrics.export.enabled=true


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- 운영 환경에서 불필요한 Actuator 엔드포인트 노출을 최소화하기 위해, management.endpoints.web.exposure.include 설정을 *에서 health,info,metrics,prometheus로 변경했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- application.properties
   - management.endpoints.web.exposure.include=health,info,metrics,prometheus
   - 전체 엔드포인트(*) 대신, 헬스체크(health), 애플리케이션 정보(info), 일반 메트릭(metrics), Prometheus 스크랩용(prometheus)만 노출하도록 설정을 변경

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
