### PR TITLE
feat: DynamoDB userId 접두사 추가 및 Actuator 엔드포인트 최소 노출 설정

### DIFF
--- a/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryDynamoRepository.java
+++ b/UserService/src/main/java/ready_to_marry/userservice/notification/repository/NotificationHistoryDynamoRepository.java
@@ -34,6 +34,7 @@ public class NotificationHistoryDynamoRepository implements NotificationHistoryR
     @Override
     public List<NotificationHistoryResponse> findByUserId(String userId, DynamoPagingRequest pagingRequest) {
         // 1) QueryRequest 빌더 생성
+        userId = "user" + userId;
         QueryRequest.Builder queryBuilder = QueryRequest.builder()
                 .tableName(awsProperties.getDynamodb().getTableName())
                 .keyConditionExpression("id = :userId")

--- a/UserService/src/main/resources/application.properties
+++ b/UserService/src/main/resources/application.properties
@@ -21,7 +21,7 @@ spring.data.redis.sentinel.password=${SPRING_DATA_REDIS_SENTINEL_PASSWORD}
 spring.data.redis.password=${SPRING_DATA_REDIS_PASSWORD}
 
 # /actuator
-management.endpoints.web.exposure.include=*
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.base-path=/actuator
 management.prometheus.metrics.export.enabled=true


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- NotificationHistory 조회 시 DynamoDB 파티션 키 규격(user{ID})에 맞추기 위해 userId에 user 접두사를 추가하고, 운영 환경에서 불필요한 Actuator 엔드포인트 노출을 최소화했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- DynamoDB 조회 수정(fix/notification-dynamo-userid-prefix)
- Actuator 노출 설정 변경 (feat/limit-actuator-exposure)

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
